### PR TITLE
Command string parsing with quoted value support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,21 +86,39 @@ KUBECONFIG
 OUTPUT
 WORKDIR
 ```
-Each directive can receive named parameters to pass values to the command it represents.  Each named parameter uses an identifier followed by a colon `:` as shown below:
+Each directive can receive named parameters that pass values to the command it represents.  Each named parameter uses an identifier that  is followed by a colon `:` and the value of the paramter as shown below:
+
 ```
 DIRECTIVE name0:<param value 0> name1:<param value 1> ... nameN:<param value N>
 ```
+Example:
+
+```
+OUTPUT path:/tmp/crashout/out.tar.gz
+```
+
+The value of the parameter may also be quoted if necessary to capture spaces as shown in the following example:
+
+```
+CAPTURE cmd:'/bin/echo "HELLO WORLD!"'
+```
+
 Optionally, some directives can be declared with a single default parameter value as shown below:
+
 ```
 DIRECTIVE <default param value>
 ```
-As an example, directive `WORKDIR` can be declared in the following two ways:
+
+The following shows an example of directive `WORKDIR` declared with a default (unamed) parameter:
+
 ```
-WORKDIR path:/some/path
+OUTPUT /tmp/crashout/out.tar.gz
 ```
-Or `WORKDIR` can be declared with an unamed parameter which is assumed to be the `path:` parameter:
+
+This can also be done by quoting the default parameter as shown below:
+
 ```
-WORKDIR /some/path
+OUTPUT "/tmp/crashout/out.tar.gz"
 ```
 
 ### AS
@@ -132,7 +150,8 @@ Executes a shell command on the specified machines (see `FROM` directive).  The 
 ```
 CAPTURE /bin/journalctl -l -u kube-apiserver
 ```
-The previous command can be declared with its named parameter `path:` as shown below:
+Or:
+
 ```
 CAPTURE path:"/bin/journalctl -l -u kube-apiserver"
 ```
@@ -144,7 +163,8 @@ into the arhive bundle.  The COPY command can be declared with its default unanm
 ```
 COPY /var/log/kube-proxy.log
 ```
-The same command can also be declared with parameter name `paths:`
+
+Or,
 ```
 COPY paths:"/var/log/kube-proxy.log"
 ```

--- a/exec/capture_exec_test.go
+++ b/exec/capture_exec_test.go
@@ -17,7 +17,7 @@ func TestExecLocalCAPTURE(t *testing.T) {
 		{
 			name: "CAPTURE single command",
 			source: func() string {
-				return "CAPTURE /bin/echo 'HELLO WORLD'"
+				return `CAPTURE "/bin/echo 'HELLO WORLD'"`
 			},
 			exec: func(s *script.Script) error {
 				machine := s.Preambles[script.CmdFrom][0].(*script.FromCommand).Machines()[0].Host()
@@ -39,7 +39,7 @@ func TestExecLocalCAPTURE(t *testing.T) {
 		{
 			name: "CAPTURE multiple commands",
 			source: func() string {
-				return "CAPTURE /bin/echo 'HELLO WORLD'\nCAPTURE ls ."
+				return "CAPTURE '/bin/echo \"HELLO WORLD\"'\nCAPTURE ls ."
 			},
 			exec: func(s *script.Script) error {
 				machine := s.Preambles[script.CmdFrom][0].(*script.FromCommand).Machines()[0].Host()
@@ -67,7 +67,7 @@ func TestExecLocalCAPTURE(t *testing.T) {
 			name: "CAPTURE command with user specified",
 			source: func() string {
 				uid := os.Getuid()
-				return fmt.Sprintf("AS userid:%d \nCAPTURE /bin/echo 'HELLO WORLD'", uid)
+				return fmt.Sprintf("AS userid:%d \nCAPTURE '/bin/echo \"HELLO WORLD\"'", uid)
 			},
 			exec: func(s *script.Script) error {
 				machine := s.Preambles[script.CmdFrom][0].(*script.FromCommand).Machines()[0].Host()

--- a/script/as_cmd_test.go
+++ b/script/as_cmd_test.go
@@ -35,6 +35,29 @@ func TestCommandAS(t *testing.T) {
 			},
 		},
 		{
+			name: "AS with quoted userid and groupid",
+			source: func() string {
+				return `AS userid:"foo" groupid:bar`
+			},
+			script: func(s *Script) error {
+				cmds := s.Preambles[CmdAs]
+				if len(cmds) != 1 {
+					return fmt.Errorf("Script missing preamble %s", CmdAs)
+				}
+				asCmd, ok := cmds[0].(*AsCommand)
+				if !ok {
+					return fmt.Errorf("Unexpected type %T in script", cmds[0])
+				}
+				if asCmd.GetUserId() != "foo" {
+					return fmt.Errorf("Unexpected AS userid %s", asCmd.GetUserId())
+				}
+				if asCmd.GetGroupId() != "bar" {
+					return fmt.Errorf("Unexpected AS groupid %s", asCmd.GetUserId())
+				}
+				return nil
+			},
+		},
+		{
 			name: "AS with only userid",
 			source: func() string {
 				return "AS userid:foo"

--- a/script/authconfig_cmd.go
+++ b/script/authconfig_cmd.go
@@ -7,7 +7,7 @@ import "fmt"
 
 // AuthConfigCommand represents AUTHCONFIG directive:
 //
-// AUTHCONFIG username:username private-key:/path/to/key api-key:key
+// AUTHCONFIG username:"username" private-key:"/path/to/key api-key:key"
 //
 // Param username is required
 type AuthConfigCommand struct {
@@ -24,11 +24,12 @@ func NewAuthConfigCommand(index int, rawArgs string) (*AuthConfigCommand, error)
 	if err != nil {
 		return nil, fmt.Errorf("AUTHCONFIG: %v", err)
 	}
-
-	cmd := &AuthConfigCommand{cmd: cmd{index: index, name: CmdAuthConfig, args: argMap}}
 	if err := validateCmdArgs(CmdAuthConfig, argMap); err != nil {
 		return nil, err
 	}
+
+	cmd := &AuthConfigCommand{cmd: cmd{index: index, name: CmdAuthConfig, args: argMap}}
+
 	return cmd, nil
 }
 

--- a/script/authconfig_cmd_test.go
+++ b/script/authconfig_cmd_test.go
@@ -34,6 +34,29 @@ func TestCommandAUTHCONFIG(t *testing.T) {
 			},
 		},
 		{
+			name: "AUTHCONFIG - quoted params",
+			source: func() string {
+				return "AUTHCONFIG username:test-user private-key:'/a/b/c'"
+			},
+			script: func(s *Script) error {
+				cmds := s.Preambles[CmdAuthConfig]
+				if len(cmds) != 1 {
+					return fmt.Errorf("Script missing preamble %s", CmdAuthConfig)
+				}
+				authCmd, ok := cmds[0].(*AuthConfigCommand)
+				if !ok {
+					return fmt.Errorf("Unexpected type %T in script", cmds[0])
+				}
+				if authCmd.GetUsername() != "test-user" {
+					return fmt.Errorf("Unexpected username %s", authCmd.GetUsername())
+				}
+				if authCmd.GetPrivateKey() != "/a/b/c" {
+					return fmt.Errorf("Unexpected private-key %s", authCmd.GetPrivateKey())
+				}
+				return nil
+			},
+		},
+		{
 			name: "AUTHCONFIG with only private-key",
 			source: func() string {
 				return "AUTHCONFIG private-key:/a/b/c"

--- a/script/capture_cmd_test.go
+++ b/script/capture_cmd_test.go
@@ -11,7 +11,7 @@ import (
 func TestCommandCAPTURE(t *testing.T) {
 	tests := []commandTest{
 		{
-			name: "CAPTURE single command",
+			name: "CAPTURE default param",
 			source: func() string {
 				return "CAPTURE /bin/echo HELLO WORLD"
 			},
@@ -33,6 +33,64 @@ func TestCommandCAPTURE(t *testing.T) {
 					return fmt.Errorf("CAPTURE action parsed cli unexpected command %s", cliCmd)
 				}
 				if len(cliArgs) != 2 {
+					return fmt.Errorf("CAPTURE action parsed cli unexpected args %d", len(cliArgs))
+				}
+
+				return nil
+			},
+		},
+		{
+			name: "CAPTURE default quoted param",
+			source: func() string {
+				return `CAPTURE '/bin/echo "HELLO WORLD"'`
+			},
+			script: func(s *Script) error {
+				if len(s.Actions) != 1 {
+					return fmt.Errorf("Script has unexpected actions, needs %d", len(s.Actions))
+				}
+				cmd, ok := s.Actions[0].(*CaptureCommand)
+				if !ok {
+					return fmt.Errorf("Unexpected action type %T in script", s.Actions[0])
+				}
+
+				if cmd.Args()["cmd"] != cmd.GetCmdString() {
+					return fmt.Errorf("CAPTURE action with unexpected CLI string %s", cmd.GetCmdString())
+				}
+
+				cliCmd, cliArgs := cmd.GetParsedCmd()
+				if cliCmd != "/bin/echo" {
+					return fmt.Errorf("CAPTURE action parsed cli unexpected command %s", cliCmd)
+				}
+				if len(cliArgs) != 1 {
+					return fmt.Errorf("CAPTURE action parsed cli unexpected args %d", len(cliArgs))
+				}
+
+				return nil
+			},
+		},
+		{
+			name: "CAPTURE single quoted command",
+			source: func() string {
+				return `CAPTURE cmd:"/bin/echo 'HELLO WORLD'"`
+			},
+			script: func(s *Script) error {
+				if len(s.Actions) != 1 {
+					return fmt.Errorf("Script has unexpected actions, needs %d", len(s.Actions))
+				}
+				cmd, ok := s.Actions[0].(*CaptureCommand)
+				if !ok {
+					return fmt.Errorf("Unexpected action type %T in script", s.Actions[0])
+				}
+
+				if cmd.Args()["cmd"] != cmd.GetCmdString() {
+					return fmt.Errorf("CAPTURE action with unexpected CLI string %s", cmd.GetCmdString())
+				}
+
+				cliCmd, cliArgs := cmd.GetParsedCmd()
+				if cliCmd != "/bin/echo" {
+					return fmt.Errorf("CAPTURE action parsed cli unexpected command %s", cliCmd)
+				}
+				if len(cliArgs) != 1 {
 					return fmt.Errorf("CAPTURE action parsed cli unexpected args %d", len(cliArgs))
 				}
 

--- a/script/copy_cmd.go
+++ b/script/copy_cmd.go
@@ -5,7 +5,6 @@ package script
 
 import (
 	"fmt"
-	"strings"
 )
 
 // CopyCommand represents a COPY directive which may have
@@ -28,19 +27,21 @@ func NewCopyCommand(index int, rawArgs string) (*CopyCommand, error) {
 
 	// determine shape of directive
 	var argMap map[string]string
-	if strings.Contains(rawArgs, "paths:") {
-		args, err := mapArgs(rawArgs)
-		if err != nil {
-			return nil, fmt.Errorf("COPY: %v", err)
-		}
-		argMap = args
-	} else {
-		argMap = map[string]string{"paths": rawArgs}
+	if !isNamedParam(rawArgs) {
+		// setup default param (notice quoted value)
+		rawArgs = makeNamedPram("paths", rawArgs)
 	}
-	cmd := &CopyCommand{cmd: cmd{index: index, name: CmdCopy, args: argMap}}
+	argMap, err := mapArgs(rawArgs)
+	if err != nil {
+		return nil, fmt.Errorf("COPY: %v", err)
+	}
+
 	if err := validateCmdArgs(CmdCopy, argMap); err != nil {
 		return nil, err
 	}
+
+	cmd := &CopyCommand{cmd: cmd{index: index, name: CmdCopy, args: argMap}}
+
 	return cmd, nil
 }
 

--- a/script/copy_cmd_test.go
+++ b/script/copy_cmd_test.go
@@ -10,9 +10,53 @@ import (
 func TestCommandCOPY(t *testing.T) {
 	tests := []commandTest{
 		{
-			name: "COPY with single arg",
+			name: "COPY with default param",
 			source: func() string {
 				return "COPY /a/b/c"
+			},
+			script: func(s *Script) error {
+				if len(s.Actions) != 1 {
+					return fmt.Errorf("Script has unexpected COPY actions, has %d COPY", len(s.Actions))
+				}
+
+				cmd := s.Actions[0].(*CopyCommand)
+				if len(cmd.Paths()) != 1 {
+					return fmt.Errorf("COPY has unexpected number of paths %d", len(cmd.Paths()))
+				}
+
+				arg := cmd.Paths()[0]
+				if arg != "/a/b/c" {
+					return fmt.Errorf("COPY has unexpected argument %s", arg)
+				}
+				return nil
+			},
+		},
+		{
+			name: "COPY with quoted default param",
+			source: func() string {
+				return `COPY '/a/b/c'`
+			},
+			script: func(s *Script) error {
+				if len(s.Actions) != 1 {
+					return fmt.Errorf("Script has unexpected COPY actions, has %d COPY", len(s.Actions))
+				}
+
+				cmd := s.Actions[0].(*CopyCommand)
+				if len(cmd.Paths()) != 1 {
+					return fmt.Errorf("COPY has unexpected number of paths %d", len(cmd.Paths()))
+				}
+
+				arg := cmd.Paths()[0]
+				if arg != "/a/b/c" {
+					return fmt.Errorf("COPY has unexpected argument %s", arg)
+				}
+				return nil
+			},
+		},
+		{
+			name: "COPY with quoted named param",
+			source: func() string {
+				return `COPY paths:"/a/b/c"`
 			},
 			script: func(s *Script) error {
 				if len(s.Actions) != 1 {
@@ -108,6 +152,30 @@ func TestCommandCOPY(t *testing.T) {
 				if arg != "/a/b/c" {
 					return fmt.Errorf("COPY has unexpected argument %s", arg)
 				}
+				return nil
+			},
+		},
+		{
+			name: "COPY with named params with multiple paths",
+			source: func() string {
+				return `COPY paths:"/a/b/c /e/f/g"`
+			},
+			script: func(s *Script) error {
+				if len(s.Actions) != 1 {
+					return fmt.Errorf("Script has unexpected COPY actions, has %d COPY", len(s.Actions))
+				}
+
+				cmd := s.Actions[0].(*CopyCommand)
+				if len(cmd.Paths()) != 2 {
+					return fmt.Errorf("COPY has unexpected number of args %d", len(cmd.Paths()))
+				}
+				if cmd.Paths()[0] != "/a/b/c" {
+					return fmt.Errorf("COPY has unexpected argument[0] %s", cmd.Paths()[0])
+				}
+				if cmd.Paths()[1] != "/e/f/g" {
+					return fmt.Errorf("COPY has unexpected argument[1] %s", cmd.Paths()[1])
+				}
+
 				return nil
 			},
 		},

--- a/script/env_cmd.go
+++ b/script/env_cmd.go
@@ -33,14 +33,13 @@ func NewEnvCommand(index int, rawArgs string) (*EnvCommand, error) {
 
 	// map params
 	var argMap map[string]string
-	if strings.Contains(rawArgs, "vars:") {
-		args, err := mapArgs(rawArgs)
-		if err != nil {
-			return nil, fmt.Errorf("ENV: %v", err)
-		}
-		argMap = args
-	} else {
-		argMap = map[string]string{"vars": rawArgs}
+	if !isNamedParam(rawArgs) {
+		// setup default param (notice quoted value)
+		rawArgs = makeNamedPram("vars", rawArgs)
+	}
+	argMap, err := mapArgs(rawArgs)
+	if err != nil {
+		return nil, fmt.Errorf("ENV: %v", err)
 	}
 
 	cmd := &EnvCommand{

--- a/script/env_cmd_test.go
+++ b/script/env_cmd_test.go
@@ -37,7 +37,7 @@ func TestCommandENV(t *testing.T) {
 		{
 			name: "Multiple ENV with multiple args",
 			source: func() string {
-				return "ENV a=b\nENV c=d e=f"
+				return "ENV a=b\nENV 'c=d e=f'"
 			},
 			script: func(s *Script) error {
 				envs := s.Preambles[CmdEnv]
@@ -92,6 +92,32 @@ func TestCommandENV(t *testing.T) {
 				env := envCmd.Envs()["abc"]
 				if env != "defgh" {
 					return fmt.Errorf("ENV has unexpected value: %#v", envCmd.Envs())
+				}
+				return nil
+			},
+		},
+		{
+			name: "ENV with multiple quoted vars",
+			source: func() string {
+				return `ENV vars:'a=b c=d e=f'`
+			},
+			script: func(s *Script) error {
+				envs := s.Preambles[CmdEnv]
+				if len(envs) != 1 {
+					return fmt.Errorf("Script has unexpected number of ENV %d", len(envs))
+				}
+
+				envCmd0 := envs[0].(*EnvCommand)
+				if len(envCmd0.Envs()) != 3 {
+					return fmt.Errorf("ENV has unexpected number of env %d", len(envCmd0.Envs()))
+				}
+				env := envCmd0.Envs()["a"]
+				if env != "b" {
+					return fmt.Errorf("ENV has unexpected value a=%s", envCmd0.Envs()["a"])
+				}
+				env0, env1 := envCmd0.Envs()["c"], envCmd0.Envs()["e"]
+				if env0 != "d" || env1 != "f" {
+					return fmt.Errorf("ENV has unexpected values env[c]=%s and env[e]=%s", env0, env1)
 				}
 				return nil
 			},

--- a/script/from_cmd.go
+++ b/script/from_cmd.go
@@ -53,16 +53,18 @@ func NewFromCommand(index int, rawArgs string) (*FromCommand, error) {
 		return nil, err
 	}
 
+	// named param mapping is done differently
+	// because address for hosts contains char ':'
 	var argMap map[string]string
-	if strings.Contains(rawArgs, "hosts:") {
-		args, err := mapArgs(rawArgs)
-		if err != nil {
-			return nil, fmt.Errorf("ENV: %v", err)
-		}
-		argMap = args
-	} else {
-		argMap = map[string]string{"hosts": rawArgs}
+	// if no pram named 'hosts' found, assume raw default
+	if !strings.Contains(rawArgs, "hosts:") {
+		rawArgs = makeNamedPram("hosts", rawArgs)
 	}
+	argMap, err := mapArgs(rawArgs)
+	if err != nil {
+		return nil, fmt.Errorf("CAPTURE: %v", err)
+	}
+
 	cmd := &FromCommand{cmd: cmd{index: index, name: CmdFrom, args: argMap}}
 	if err := validateCmdArgs(CmdFrom, argMap); err != nil {
 		return nil, err

--- a/script/from_cmd_test.go
+++ b/script/from_cmd_test.go
@@ -37,7 +37,7 @@ func TestCommandFROM(t *testing.T) {
 		{
 			name: "FROM set to single remote machine",
 			source: func() string {
-				return "FROM foo.bar:1234"
+				return "FROM 'foo.bar:1234'"
 			},
 			script: func(s *Script) error {
 				froms := s.Preambles[CmdFrom]
@@ -65,7 +65,7 @@ func TestCommandFROM(t *testing.T) {
 		{
 			name: "FROM with multiple machines",
 			source: func() string {
-				return "FROM local 127.0.0.1:1234"
+				return "FROM 'local 127.0.0.1:1234'"
 			},
 			script: func(s *Script) error {
 				froms := s.Preambles[CmdFrom]
@@ -74,6 +74,7 @@ func TestCommandFROM(t *testing.T) {
 				}
 				fromCmd := froms[0].(*FromCommand)
 				if len(fromCmd.Machines()) != 2 {
+					t.Log("Machines:", fromCmd.Machines())
 					return fmt.Errorf("FROM has unexpected number of machines %d", len(fromCmd.Machines()))
 				}
 				m0 := fromCmd.Machines()[0]

--- a/script/kubecfg_cmd.go
+++ b/script/kubecfg_cmd.go
@@ -5,7 +5,6 @@ package script
 
 import (
 	"fmt"
-	"strings"
 )
 
 // KubeConfigCommand represents a KUBECONFIG directive which can have
@@ -23,14 +22,13 @@ func NewKubeConfigCommand(index int, rawArgs string) (*KubeConfigCommand, error)
 	}
 
 	var argMap map[string]string
-	if strings.Contains(rawArgs, "path:") {
-		args, err := mapArgs(rawArgs)
-		if err != nil {
-			return nil, fmt.Errorf("KUBECONFIG: %v", err)
-		}
-		argMap = args
-	} else {
-		argMap = map[string]string{"path": rawArgs}
+	if !isNamedParam(rawArgs) {
+		// setup default param (notice quoted value)
+		rawArgs = makeNamedPram("path", rawArgs)
+	}
+	argMap, err := mapArgs(rawArgs)
+	if err != nil {
+		return nil, fmt.Errorf("KUBECONFIG: %v", err)
 	}
 
 	cmd := &KubeConfigCommand{cmd: cmd{index: index, name: CmdKubeConfig, args: argMap}}

--- a/script/kubecfg_cmd_test.go
+++ b/script/kubecfg_cmd_test.go
@@ -33,7 +33,7 @@ func TestCommandKUBECONFIG(t *testing.T) {
 		{
 			name: "Script with multiple KUBECONFIG",
 			source: func() string {
-				return "KUBECONFIG /a/b/c\nKUBECONFIG /e/f/g"
+				return "KUBECONFIG /a/b/c\nKUBECONFIG '/e/f/g'"
 			},
 			script: func(s *Script) error {
 				cfgs := s.Preambles[CmdKubeConfig]
@@ -54,6 +54,26 @@ func TestCommandKUBECONFIG(t *testing.T) {
 			name: "KUBECONFIG with single namped param",
 			source: func() string {
 				return "KUBECONFIG path:/a/b/c"
+			},
+			script: func(s *Script) error {
+				cfgs := s.Preambles[CmdKubeConfig]
+				if len(cfgs) != 1 {
+					return fmt.Errorf("Script has unexpected number of KUBECONFIG %d", len(cfgs))
+				}
+				cfg, ok := cfgs[0].(*KubeConfigCommand)
+				if !ok {
+					return fmt.Errorf("Unexpected type %T in script", cfgs[0])
+				}
+				if cfg.Path() != "/a/b/c" {
+					return fmt.Errorf("KUBECONFIG has unexpected config %s", cfg.Path())
+				}
+				return nil
+			},
+		},
+		{
+			name: "KUBECONFIG quoted named param",
+			source: func() string {
+				return `KUBECONFIG path:"/a/b/c"`
 			},
 			script: func(s *Script) error {
 				cfgs := s.Preambles[CmdKubeConfig]

--- a/script/output_cmd.go
+++ b/script/output_cmd.go
@@ -5,7 +5,6 @@ package script
 
 import (
 	"fmt"
-	"strings"
 )
 
 // OutputCommand representes a OUTPUT directive which can have
@@ -23,14 +22,13 @@ func NewOutputCommand(index int, rawArgs string) (*OutputCommand, error) {
 	}
 
 	var argMap map[string]string
-	if strings.Contains(rawArgs, "path:") {
-		args, err := mapArgs(rawArgs)
-		if err != nil {
-			return nil, fmt.Errorf("OUTPUT: %v", err)
-		}
-		argMap = args
-	} else {
-		argMap = map[string]string{"path": rawArgs}
+	if !isNamedParam(rawArgs) {
+		// setup default param (notice quoted value)
+		rawArgs = makeNamedPram("path", rawArgs)
+	}
+	argMap, err := mapArgs(rawArgs)
+	if err != nil {
+		return nil, fmt.Errorf("OUTPUT: %v", err)
 	}
 
 	cmd := &OutputCommand{cmd: cmd{index: index, name: CmdOutput, args: argMap}}

--- a/script/output_cmd_test.go
+++ b/script/output_cmd_test.go
@@ -11,9 +11,29 @@ import (
 func TestCommandOUTPUT(t *testing.T) {
 	tests := []commandTest{
 		{
-			name: "OUTPUT without named arg",
+			name: "OUTPUT with default param",
 			source: func() string {
 				return "OUTPUT foo/bar.tar.gz"
+			},
+			script: func(s *Script) error {
+				outs := s.Preambles[CmdOutput]
+				if len(outs) != 1 {
+					return fmt.Errorf("Script has unexpected number of OUTPUT %d", len(outs))
+				}
+				outCmd, ok := outs[0].(*OutputCommand)
+				if !ok {
+					return fmt.Errorf("Unexpected type %T in script", outs[0])
+				}
+				if outCmd.Path() != "foo/bar.tar.gz" {
+					return fmt.Errorf("OUTPUT has unexpected directory %s", outCmd.Path())
+				}
+				return nil
+			},
+		},
+		{
+			name: "OUTPUT with quoted default param",
+			source: func() string {
+				return "OUTPUT 'foo/bar.tar.gz'"
 			},
 			script: func(s *Script) error {
 				outs := s.Preambles[CmdOutput]
@@ -53,7 +73,7 @@ func TestCommandOUTPUT(t *testing.T) {
 		{
 			name: "Multiple OUTPUTs",
 			source: func() string {
-				return "OUTPUT path:foo/bar\nOUTPUT bazz/buzz.tar.gz"
+				return "OUTPUT path:foo/bar\nOUTPUT path:'bazz/buzz.tar.gz'"
 			},
 			script: func(s *Script) error {
 				outs := s.Preambles[CmdOutput]

--- a/script/words_split.go
+++ b/script/words_split.go
@@ -1,0 +1,109 @@
+package script
+
+import (
+	"bufio"
+	"io"
+	"strings"
+	"unicode"
+)
+
+// wordSplit splits space-separted strings into words including quoted words:
+//
+//     aaa "bbb" "ccc ddd" eee
+//
+//  In case of aaa"abcd", the whole thing is returned as aaa"abcd" including qoutes.
+//  In case of "aaa"bbb will be returned as two words "aaa" and "bbb"
+func wordSplit(val string) ([]string, error) {
+	rdr := bufio.NewReader(strings.NewReader(val))
+	var startQuote rune
+	var word strings.Builder
+	words := make([]string, 0)
+	inWord := false
+	inQuote := false
+	squashed := false
+
+	for {
+		token, _, err := rdr.ReadRune()
+		if err != nil {
+			if err == io.EOF {
+				remainder := word.String()
+				if len(remainder) > 0 {
+					words = append(words, remainder)
+				}
+				return words, nil
+			}
+			return nil, err
+		}
+
+		switch {
+		case isChar(token):
+			if !inWord {
+				inWord = true
+			}
+			word.WriteRune(token)
+
+		case isQuote(token):
+			if !inWord {
+				inWord, inQuote = true, true
+				startQuote = token
+				continue
+			}
+
+			// handles case when unquoted runs into quoted: abc"defg"
+			// start the quote here
+			if inWord && !inQuote {
+				inQuote, squashed = true, true
+				startQuote = token
+				word.WriteRune(token)
+				continue
+			}
+
+			// handle embedded quote (i.e "'aa'")
+			if inWord && inQuote && token != startQuote {
+				word.WriteRune(token)
+				continue
+			}
+
+			// capture closing quote when in abc"defg"
+			if squashed {
+				word.WriteRune(token)
+			}
+
+			inWord = false
+			inQuote = false
+			squashed = false
+			//store
+			words = append(words, word.String())
+			word.Reset()
+
+		case unicode.IsSpace(token):
+			if !inWord {
+				inWord = false
+				continue
+			}
+
+			// capture quoted space
+			if inWord && inQuote {
+				word.WriteRune(token)
+				continue
+			}
+
+			// end of word
+			inWord = false
+			words = append(words, word.String())
+			word.Reset()
+		}
+	}
+}
+
+func isQuote(r rune) bool {
+	switch r {
+	case '"', '\'':
+		return true
+	}
+	return false
+}
+
+func isChar(r rune) bool {
+	return !isQuote(r) && !unicode.IsSpace(r)
+}

--- a/script/words_split_test.go
+++ b/script/words_split_test.go
@@ -1,0 +1,74 @@
+package script
+
+import "testing"
+
+func TestWordSplit(t *testing.T) {
+	tests := []struct {
+		name  string
+		str   string
+		words []string
+	}{
+		{
+			name:  "no quotes",
+			str:   `aaa bbb ccc ddd`,
+			words: []string{"aaa", "bbb", "ccc", "ddd"},
+		},
+		{
+			name:  "all quotes",
+			str:   `"aaa" "bbb" "ccc" "ddd"`,
+			words: []string{"aaa", "bbb", "ccc", "ddd"},
+		},
+		{
+			name:  "mix unquoted quoted",
+			str:   `aaa "bbb" "ccc ddd"`,
+			words: []string{"aaa", "bbb", "ccc ddd"},
+		},
+		{
+			name:  "mix quoted unquoted",
+			str:   `"aaa" "bbb ccc" ddd`,
+			words: []string{"aaa", "bbb ccc", "ddd"},
+		},
+		{
+			name:  "front quote runin",
+			str:   `aaa"bbb ccc" ddd`,
+			words: []string{"aaa\"bbb ccc\"", "ddd"},
+		},
+		{
+			name:  "back quote runin",
+			str:   `aaa "bbb ccc"ddd`,
+			words: []string{"aaa", "bbb ccc", "ddd"},
+		},
+		{
+			name:  "embedded single quotes",
+			str:   `aaa "'bbb' ccc" ddd`,
+			words: []string{"aaa", "'bbb' ccc", "ddd"},
+		},
+		{
+			name:  "embedded double quotes",
+			str:   `'aaa' '"bbb ccc"' ddd`,
+			words: []string{"aaa", `"bbb ccc"`, "ddd"},
+		},
+		{
+			name:  "embedded quoted runins",
+			str:   `aaa'"bbb ccc"' ddd`,
+			words: []string{`aaa'"bbb ccc"'`, "ddd"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			words, err := wordSplit(test.str)
+			if err != nil {
+				t.Error(err)
+			}
+			if len(words) != len(test.words) {
+				t.Fatalf("unexpected length: want %#v, got %#v", test.words, words)
+			}
+			for i := range words {
+				if words[i] != test.words[i] {
+					t.Errorf("word mistached:\ngot %#v\nwant %#v", words, test.words)
+				}
+			}
+		})
+	}
+}

--- a/script/workdir_cmd.go
+++ b/script/workdir_cmd.go
@@ -5,7 +5,6 @@ package script
 
 import (
 	"fmt"
-	"strings"
 )
 
 // WorkdirCommand representes a WORKDIR which may have one
@@ -24,14 +23,13 @@ func NewWorkdirCommand(index int, rawArgs string) (*WorkdirCommand, error) {
 	}
 
 	var argMap map[string]string
-	if strings.Contains(rawArgs, "path:") {
-		args, err := mapArgs(rawArgs)
-		if err != nil {
-			return nil, fmt.Errorf("WORKDIR: %v", err)
-		}
-		argMap = args
-	} else {
-		argMap = map[string]string{"path": rawArgs}
+	if !isNamedParam(rawArgs) {
+		// setup default param (notice quoted value)
+		rawArgs = makeNamedPram("path", rawArgs)
+	}
+	argMap, err := mapArgs(rawArgs)
+	if err != nil {
+		return nil, fmt.Errorf("WORKDIR: %v", err)
 	}
 
 	cmd := &WorkdirCommand{cmd: cmd{index: index, name: CmdWorkDir, args: argMap}}

--- a/script/workdir_cmd_test.go
+++ b/script/workdir_cmd_test.go
@@ -11,7 +11,7 @@ import (
 func TestCommandWORKDIR(t *testing.T) {
 	tests := []commandTest{
 		{
-			name: "WORKDIR with single arg",
+			name: "WORKDIR with default param",
 			source: func() string {
 				return "WORKDIR foo/bar"
 			},
@@ -33,7 +33,7 @@ func TestCommandWORKDIR(t *testing.T) {
 		{
 			name: "Multiple WORKDIRs",
 			source: func() string {
-				return "WORKDIR foo/bar\nWORKDIR bazz/buzz"
+				return "WORKDIR foo/bar\nWORKDIR 'bazz/buzz'"
 			},
 			script: func(s *Script) error {
 				dirs := s.Preambles[CmdWorkDir]
@@ -54,6 +54,26 @@ func TestCommandWORKDIR(t *testing.T) {
 			name: "WORKDIR with named param",
 			source: func() string {
 				return "WORKDIR path:foo/bar"
+			},
+			script: func(s *Script) error {
+				dirs := s.Preambles[CmdWorkDir]
+				if len(dirs) != 1 {
+					return fmt.Errorf("Script has unexpected number of WORKDIR %d", len(dirs))
+				}
+				wdCmd, ok := dirs[0].(*WorkdirCommand)
+				if !ok {
+					return fmt.Errorf("Unexpected type %T in script", dirs[0])
+				}
+				if wdCmd.Path() != "foo/bar" {
+					return fmt.Errorf("WORKDIR has unexpected directory %s", wdCmd.Path())
+				}
+				return nil
+			},
+		},
+		{
+			name: "WORKDIR with quoted named param",
+			source: func() string {
+				return "WORKDIR path:'foo/bar'"
 			},
 			script: func(s *Script) error {
 				dirs := s.Preambles[CmdWorkDir]


### PR DESCRIPTION
This PR refactors the parsing facility in the code to support quoted values i.e.:
* `DIRECTIVE "default param value"`
* `DIRECTIVE param:'aaa "bbb ccc ddd"'`

This PR fixes #11 