### PR TITLE
Change Run command's error info

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ Next run `crash-diagnostics` using the sample Diagnostics.file in this directory
 current environment:
 
 ```
-crash-diagnostics run --output crashd.tar.gzip --loglevel debug
+crash-diagnostics run --output crashd.tar.gzip --debug
 ```
 
 You should see log messages on the screen similar to the following:

--- a/script/run_cmd.go
+++ b/script/run_cmd.go
@@ -36,18 +36,18 @@ func NewRunCommand(index int, rawArgs string) (*RunCommand, error) {
 	}
 	argMap, err := mapArgs(rawArgs)
 	if err != nil {
-		return nil, fmt.Errorf("CAPTURE: %v", err)
+		return nil, fmt.Errorf("RUN: %v", err)
 	}
 
 	if err := validateCmdArgs(CmdCapture, argMap); err != nil {
-		return nil, fmt.Errorf("CAPTURE: %s", err)
+		return nil, fmt.Errorf("RUN: %s", err)
 	}
 
 	cmd := &RunCommand{cmd: cmd{index: index, name: CmdCapture, args: argMap}}
 
 	cmdName, cmdArgs, err := cmdParse(cmd.GetCmdString())
 	if err != nil {
-		return nil, fmt.Errorf("CAPTURE: %s", err)
+		return nil, fmt.Errorf("RUN: %s", err)
 	}
 	cmd.cmdName = cmdName
 	cmd.cmdArgs = cmdArgs


### PR DESCRIPTION
- `Run` command's error info currently is 'CAPTURE:'
- Modify README.md: `--loglevel debug` -> `--debug`