### PR TITLE
Fix Command Quote Handling

### DIFF
--- a/exec/cli.go
+++ b/exec/cli.go
@@ -21,7 +21,7 @@ func CliRun(uid, gid uint32, cmd string, args ...string) (io.Reader, error) {
 		Credential: &syscall.Credential{Uid: uid, Gid: gid, NoSetGroups: true},
 	}
 
-	logrus.Debugf("Running %s %v (uid=%d,gid=%d)", cmd, args, uid, gid)
+	logrus.Debugf("Running %s %#v (uid=%d,gid=%d)", cmd, args, uid, gid)
 	if err := command.Run(); err != nil {
 		os.Setenv("CMD_EXITCODE", fmt.Sprintf("%d", command.ProcessState.ExitCode()))
 		os.Setenv("CMD_PID", fmt.Sprintf("%d", command.ProcessState.Pid()))

--- a/exec/executor_test.go
+++ b/exec/executor_test.go
@@ -112,7 +112,7 @@ func makeRemoteTestFile(t *testing.T, addr, fileName, content string) error {
 	defer sshc.Hangup()
 
 	t.Logf("creating remote test file %s", fileName)
-	_, err = sshc.SSHRun("echo", fmt.Sprintf("\"%s\"", content), ">", fileName)
+	_, err = sshc.SSHRun(fmt.Sprintf(`echo '%s' > %s`, content, fileName))
 	if err != nil {
 		return err
 	}
@@ -130,7 +130,7 @@ func removeRemoteTestFile(t *testing.T, addr, fileName string) error {
 	}
 	defer sshc.Hangup()
 	t.Logf("removing remote test file %s", fileName)
-	_, err = sshc.SSHRun("rm", "-rf", fileName)
+	_, err = sshc.SSHRun(fmt.Sprintf("rm -rf %s", fileName))
 	if err != nil {
 		return err
 	}
@@ -148,7 +148,7 @@ func makeRemoteTestDir(t *testing.T, addr, path string) error {
 	}
 	defer sshc.Hangup()
 	t.Logf("creating remote test  dir %s", path)
-	_, err = sshc.SSHRun("mkdir", "-p", path)
+	_, err = sshc.SSHRun(fmt.Sprintf("mkdir -p %s", path))
 	if err != nil {
 		return err
 	}

--- a/exec/remote_exec.go
+++ b/exec/remote_exec.go
@@ -70,19 +70,18 @@ func captureRemotely(user, privKey, hostAddr string, cmdCap *script.CaptureComma
 	}
 	defer sshc.Hangup()
 
-	cmdStr := cmdCap.GetCmdString()
-	cliCmd, cliArgs, err := cmdCap.GetParsedCmd()
+	cmdStr, err := cmdCap.GetEffectiveCmdStr()
 	if err != nil {
 		return err
 	}
 
 	fileName := fmt.Sprintf("%s.txt", sanitizeStr(cmdStr))
 	filePath := filepath.Join(workdir, fileName)
-	logrus.Debugf("Capturing remote command [%s] -into-> %s", cmdStr, filePath)
+	logrus.Debugf("CAPTURE command [%s] -into-> %s", cmdStr, filePath)
 
-	cmdReader, err := sshc.SSHRun(cliCmd, cliArgs...)
+	cmdReader, err := sshc.SSHRun(cmdStr)
 	if err != nil {
-		sshErr := fmt.Errorf("remote command %s failed: %s", cliCmd, err)
+		sshErr := fmt.Errorf("CAPTURE remote command %s failed: %s", cmdStr, err)
 		logrus.Warn(sshErr)
 		return writeError(sshErr, filePath)
 	}
@@ -101,17 +100,14 @@ func runRemotely(user, privKey, hostAddr string, cmdRun *script.RunCommand, work
 	}
 	defer sshc.Hangup()
 
-	cmdStr := cmdRun.GetCmdString()
-	cliCmd, cliArgs, err := cmdRun.GetParsedCmd()
+	cmdStr, err := cmdRun.GetEffectiveCmdStr()
 	if err != nil {
 		return err
 	}
 
-	logrus.Debugf("Running remote command: %s", cmdStr)
-
-	cmdReader, err := sshc.SSHRun(cliCmd, cliArgs...)
+	cmdReader, err := sshc.SSHRun(cmdStr)
 	if err != nil {
-		sshErr := fmt.Errorf("Command failed: %s: %s", cliCmd, err)
+		sshErr := fmt.Errorf("RUN remote command failed: %s: %s", cmdStr, err)
 		logrus.Error(sshErr)
 		return nil
 	}

--- a/script/capture_cmd_test.go
+++ b/script/capture_cmd_test.go
@@ -12,13 +12,13 @@ import (
 func TestCommandCAPTURE(t *testing.T) {
 	tests := []commandTest{
 		{
-			name: "CAPTURE default param",
+			name: "CAPTURE with unqoted default with quoted param",
 			source: func() string {
-				return "CAPTURE /bin/echo HELLO WORLD"
+				return `CAPTURE /bin/echo "HELLO WORLD"`
 			},
 			script: func(s *Script) error {
 				if len(s.Actions) != 1 {
-					return fmt.Errorf("Script has unexpected actions, needs %d", len(s.Actions))
+					return fmt.Errorf("Script has unexpected action count, needs %d", len(s.Actions))
 				}
 				cmd, ok := s.Actions[0].(*CaptureCommand)
 				if !ok {
@@ -26,141 +26,174 @@ func TestCommandCAPTURE(t *testing.T) {
 				}
 
 				if cmd.Args()["cmd"] != cmd.GetCmdString() {
-					return fmt.Errorf("CAPTURE action with unexpected CLI string %s", cmd.GetCmdString())
+					return fmt.Errorf("CAPTURE action with unexpected command string %s", cmd.GetCmdString())
 				}
-
 				cliCmd, cliArgs, err := cmd.GetParsedCmd()
 				if err != nil {
-					return fmt.Errorf("CAPTURE command parse failed: %s", cmd.GetCmdString())
+					return fmt.Errorf("CAPTURE command parse failed: %s", err)
 				}
 				if cliCmd != "/bin/echo" {
-					return fmt.Errorf("CAPTURE action parsed cli unexpected command %s", cliCmd)
+					return fmt.Errorf("CAPTURE unexpected command parsed: %s", cliCmd)
+				}
+				if len(cliArgs) != 1 {
+					return fmt.Errorf("CAPTURE unexpected command args parsed: %d", len(cliArgs))
+				}
+				if cliArgs[0] != "HELLO WORLD" {
+					return fmt.Errorf("CAPTURE has unexpected cli args: %#v", cliArgs)
+				}
+				return nil
+			},
+		},
+		{
+			name: "CAPTURE single-quoted default with quoted param",
+			source: func() string {
+				return `CAPTURE '/bin/echo -n "HELLO WORLD"'`
+			},
+			script: func(s *Script) error {
+				if len(s.Actions) != 1 {
+					return fmt.Errorf("Script has unexpected actions, needs %d", len(s.Actions))
+				}
+				cmd := s.Actions[0].(*CaptureCommand)
+				if cmd.Args()["cmd"] != cmd.GetCmdString() {
+					return fmt.Errorf("CAPTURE action with unexpected CLI string %s", cmd.GetCmdString())
+				}
+				cliCmd, cliArgs, err := cmd.GetParsedCmd()
+				if err != nil {
+					return fmt.Errorf("CAPTURE command parse failed: %s", err)
+				}
+				if cliCmd != "/bin/echo" {
+					return fmt.Errorf("CAPTURE unexpected command parsed: %s", cliCmd)
 				}
 				if len(cliArgs) != 2 {
-					return fmt.Errorf("CAPTURE action parsed cli unexpected args %d", len(cliArgs))
+					return fmt.Errorf("CAPTURE unexpected command args parsed: %d", len(cliArgs))
 				}
-
+				if cliArgs[0] != "-n" {
+					return fmt.Errorf("CAPTURE has unexpected cli args: %#v", cliArgs)
+				}
+				if cliArgs[1] != "HELLO WORLD" {
+					return fmt.Errorf("CAPTURE has unexpected cli args: %#v", cliArgs)
+				}
 				return nil
 			},
 		},
 		{
-			name: "CAPTURE default quoted param",
+			name: "CAPTURE single-quoted named param with quoted arg",
 			source: func() string {
-				return `CAPTURE '/bin/echo "HELLO WORLD"'`
+				return `CAPTURE cmd:'/bin/echo -n "HELLO WORLD"'`
 			},
 			script: func(s *Script) error {
 				if len(s.Actions) != 1 {
 					return fmt.Errorf("Script has unexpected actions, needs %d", len(s.Actions))
 				}
-				cmd, ok := s.Actions[0].(*CaptureCommand)
-				if !ok {
-					return fmt.Errorf("Unexpected action type %T in script", s.Actions[0])
-				}
-
+				cmd := s.Actions[0].(*CaptureCommand)
 				if cmd.Args()["cmd"] != cmd.GetCmdString() {
 					return fmt.Errorf("CAPTURE action with unexpected CLI string %s", cmd.GetCmdString())
 				}
-
 				cliCmd, cliArgs, err := cmd.GetParsedCmd()
 				if err != nil {
-					return fmt.Errorf("CAPTURE command parse failed: %s", cmd.GetCmdString())
+					return fmt.Errorf("CAPTURE command parse failed: %s", err)
 				}
 				if cliCmd != "/bin/echo" {
-					return fmt.Errorf("CAPTURE action parsed cli unexpected command %s", cliCmd)
+					return fmt.Errorf("CAPTURE unexpected command parsed: %s", cliCmd)
 				}
-				if len(cliArgs) != 1 {
-					return fmt.Errorf("CAPTURE action parsed cli unexpected args %d", len(cliArgs))
+				if len(cliArgs) != 2 {
+					return fmt.Errorf("CAPTURE unexpected command args parsed: %d", len(cliArgs))
 				}
-
+				if cliArgs[0] != "-n" {
+					return fmt.Errorf("CAPTURE has unexpected cli args: %#v", cliArgs)
+				}
+				if cliArgs[1] != "HELLO WORLD" {
+					return fmt.Errorf("CAPTURE has unexpected cli args: %#v", cliArgs)
+				}
 				return nil
 			},
 		},
 		{
-			name: "CAPTURE single quoted command",
+			name: "CAPTURE double-quoted named param with quoted arg",
 			source: func() string {
-				return `CAPTURE cmd:"/bin/echo 'HELLO WORLD'"`
+				return `CAPTURE cmd:"/bin/echo -n 'HELLO WORLD'"`
 			},
 			script: func(s *Script) error {
 				if len(s.Actions) != 1 {
 					return fmt.Errorf("Script has unexpected actions, needs %d", len(s.Actions))
 				}
-				cmd, ok := s.Actions[0].(*CaptureCommand)
-				if !ok {
-					return fmt.Errorf("Unexpected action type %T in script", s.Actions[0])
-				}
-
+				cmd := s.Actions[0].(*CaptureCommand)
 				if cmd.Args()["cmd"] != cmd.GetCmdString() {
 					return fmt.Errorf("CAPTURE action with unexpected CLI string %s", cmd.GetCmdString())
 				}
-
 				cliCmd, cliArgs, err := cmd.GetParsedCmd()
 				if err != nil {
-					return fmt.Errorf("CAPTURE command parse failed: %s", cmd.GetCmdString())
+					return fmt.Errorf("CAPTURE command parse failed: %s", err)
 				}
 				if cliCmd != "/bin/echo" {
-					return fmt.Errorf("CAPTURE action parsed cli unexpected command %s", cliCmd)
+					return fmt.Errorf("CAPTURE unexpected command parsed: %s", cliCmd)
 				}
-				if len(cliArgs) != 1 {
-					return fmt.Errorf("CAPTURE action parsed cli unexpected args %d", len(cliArgs))
+				if len(cliArgs) != 2 {
+					return fmt.Errorf("CAPTURE unexpected command args parsed: %d", len(cliArgs))
 				}
-
+				if cliArgs[0] != "-n" {
+					return fmt.Errorf("CAPTURE has unexpected cli args: %#v", cliArgs)
+				}
+				if cliArgs[1] != "HELLO WORLD" {
+					return fmt.Errorf("CAPTURE has unexpected cli args: %#v", cliArgs)
+				}
 				return nil
 			},
 		},
 		{
 			name: "CAPTURE multiple commands",
 			source: func() string {
-				return "CAPTURE /bin/echo HELLO\nCOPY a/b\nCAPTURE /bin/clear"
+				return `
+				CAPTURE /bin/echo "HELLO WORLD"
+				CAPTURE cmd:"/bin/bash -c date"`
 			},
 			script: func(s *Script) error {
-				if len(s.Actions) != 3 {
+				if len(s.Actions) != 2 {
 					return fmt.Errorf("Script has unexpected number of actions: %d", len(s.Actions))
 				}
-				cmd0, ok := s.Actions[0].(*CaptureCommand)
-				if !ok {
-					return fmt.Errorf("Unexpected action type %T at pos 0", s.Actions[0])
-				}
-				cmd2, ok := s.Actions[2].(*CaptureCommand)
-				if !ok {
-					return fmt.Errorf("Unexpected action type %T at pos 0", s.Actions[2])
-				}
-
+				cmd0 := s.Actions[0].(*CaptureCommand)
+				cmd2 := s.Actions[1].(*CaptureCommand)
 				if cmd0.Args()["cmd"] != cmd0.GetCmdString() {
-					return fmt.Errorf("CAPTURE action 0 with unexpected CLI string %s", cmd0.GetCmdString())
+					return fmt.Errorf("CAPTURE at 0 with unexpected command string %s", cmd0.GetCmdString())
 				}
 				if cmd2.Args()["cmd"] != cmd2.GetCmdString() {
-					return fmt.Errorf("CAPTURE action 2 with unexpected CLI string %s", cmd2.GetCmdString())
+					return fmt.Errorf("CAPTURE at 2 with unexpected command string %s", cmd2.GetCmdString())
+				}
+				cliCmd, cliArgs, err := cmd2.GetParsedCmd()
+				if err != nil {
+					return fmt.Errorf("CAPTURE command parse failed: %s", err)
+				}
+				if cliCmd != "/bin/bash" {
+					return fmt.Errorf("CAPTURE unexpected command parsed: %s", cliCmd)
+				}
+				if len(cliArgs) != 2 {
+					return fmt.Errorf("CAPTURE unexpected command args parsed: %d", len(cliArgs))
+				}
+				if cliArgs[0] != "-c" {
+					return fmt.Errorf("CAPTURE has unexpected cli args: %#v", cliArgs)
+				}
+				if cliArgs[1] != "date" {
+					return fmt.Errorf("CAPTURE has unexpected cli args: %#v", cliArgs)
 				}
 				return nil
 			},
 		},
 		{
-			name: "CAPTURE with named parameters",
+			name: "CAPTURE unquoted named params",
 			source: func() string {
 				return "CAPTURE cmd:/bin/date"
 			},
 			script: func(s *Script) error {
-				if len(s.Actions) != 1 {
-					return fmt.Errorf("Script has unexpected actions, needs %d", len(s.Actions))
-				}
-				cmd, ok := s.Actions[0].(*CaptureCommand)
-				if !ok {
-					return fmt.Errorf("Unexpected action type %T in script", s.Actions[0])
-				}
-
-				if cmd.Args()["cmd"] != cmd.GetCmdString() {
-					return fmt.Errorf("CAPTURE action with unexpected CLI string %s", cmd.GetCmdString())
-				}
-
+				cmd := s.Actions[0].(*CaptureCommand)
 				cliCmd, cliArgs, err := cmd.GetParsedCmd()
 				if err != nil {
-					return fmt.Errorf("CAPTURE command parse failed: %s", cmd.GetCmdString())
+					return fmt.Errorf("CAPTURE command parse failed: %s", err)
 				}
 				if cliCmd != "/bin/date" {
-					return fmt.Errorf("CAPTURE action parsed cli unexpected command %s", cliCmd)
+					return fmt.Errorf("CAPTURE parsed unexpected command name: %s", cliCmd)
 				}
 				if len(cliArgs) != 0 {
-					return fmt.Errorf("CAPTURE action parsed cli unexpected args %d", len(cliArgs))
+					return fmt.Errorf("CAPTURE parsed unexpected command args: %d", len(cliArgs))
 				}
 
 				return nil
@@ -173,29 +206,58 @@ func TestCommandCAPTURE(t *testing.T) {
 				return `CAPTURE '/bin/echo "$msg"'`
 			},
 			script: func(s *Script) error {
+				cmd := s.Actions[0].(*CaptureCommand)
+				cliCmd, cliArgs, err := cmd.GetParsedCmd()
+				if err != nil {
+					return fmt.Errorf("CAPTURE command parse failed: %s", err)
+				}
+				if cliCmd != "/bin/echo" {
+					return fmt.Errorf("CAPTURE parsed unexpected command name %s", cliCmd)
+				}
+				if cliArgs[0] != "Hello World!" {
+					return fmt.Errorf("CAPTURE parsed unexpected command args: %s", cliArgs)
+				}
+
+				return nil
+			},
+		},
+		{
+			name: "CAPTURE quoted with shell and quoted subproc",
+			source: func() string {
+				return `CAPTURE shell:"/bin/bash -c" cmd:"echo 'HELLO WORLD'"`
+			},
+			script: func(s *Script) error {
 				if len(s.Actions) != 1 {
 					return fmt.Errorf("Script has unexpected actions, needs %d", len(s.Actions))
 				}
-				cmd, ok := s.Actions[0].(*CaptureCommand)
-				if !ok {
-					return fmt.Errorf("Unexpected action type %T in script", s.Actions[0])
-				}
-
+				cmd := s.Actions[0].(*CaptureCommand)
 				if cmd.Args()["cmd"] != cmd.GetCmdString() {
 					return fmt.Errorf("CAPTURE action with unexpected CLI string %s", cmd.GetCmdString())
 				}
 
-				cliCmd, cliArgs, err := cmd.GetParsedCmd()
-				if err != nil {
-					return fmt.Errorf("CAPTURE command parse failed: %s", cmd.GetCmdString())
+				if cmd.Args()["cmd"] != cmd.GetCmdString() {
+					return fmt.Errorf("CAPTURE action with unexpected command string %s", cmd.GetCmdString())
 				}
-				if cliCmd != "/bin/echo" {
-					return fmt.Errorf("CAPTURE action parsed cli unexpected command %s", cliCmd)
-				}
-				if len(cliArgs) != 1 {
-					return fmt.Errorf("CAPTURE action parsed cli unexpected args %d", len(cliArgs))
+				if cmd.Args()["shell"] != cmd.GetCmdShell() {
+					return fmt.Errorf("CAPTURE action with unexpected shell %s", cmd.GetCmdShell())
 				}
 
+				cliCmd, cliArgs, err := cmd.GetParsedCmd()
+				if err != nil {
+					return fmt.Errorf("CAPTURE command parse failed: %s", err)
+				}
+				if len(cliArgs) != 2 {
+					return fmt.Errorf("CAPTURE unexpected command args parsed: %#v", cliArgs)
+				}
+				if cliCmd != "/bin/bash" {
+					return fmt.Errorf("CAPTURE unexpected command parsed: %#v", cliCmd)
+				}
+				if cliArgs[0] != "-c" {
+					return fmt.Errorf("CAPTURE has unexpected shell argument: expecting -c, got %s", cliArgs[0])
+				}
+				if cliArgs[1] != "echo 'HELLO WORLD'" {
+					return fmt.Errorf("CAPTURE has unexpected shell argument: expecting -c, got %s", cliArgs[0])
+				}
 				return nil
 			},
 		},

--- a/script/commands.go
+++ b/script/commands.go
@@ -54,13 +54,13 @@ var (
 	Cmds = map[string]CommandMeta{
 		CmdAs:         CommandMeta{Name: CmdAs, MinArgs: 1, MaxArgs: 2, Supported: true},
 		CmdAuthConfig: CommandMeta{Name: CmdAuthConfig, MinArgs: 1, MaxArgs: 3, Supported: true},
-		CmdCapture:    CommandMeta{Name: CmdCapture, MinArgs: 1, MaxArgs: 1, Supported: true},
+		CmdCapture:    CommandMeta{Name: CmdCapture, MinArgs: 1, MaxArgs: 2, Supported: true},
 		CmdCopy:       CommandMeta{Name: CmdCopy, MinArgs: 1, MaxArgs: -1, Supported: true},
 		CmdEnv:        CommandMeta{Name: CmdEnv, MinArgs: 1, MaxArgs: -1, Supported: true},
 		CmdFrom:       CommandMeta{Name: CmdFrom, MinArgs: 1, MaxArgs: -1, Supported: true},
 		CmdKubeConfig: CommandMeta{Name: CmdKubeConfig, MinArgs: 1, MaxArgs: 1, Supported: true},
 		CmdOutput:     CommandMeta{Name: CmdOutput, MinArgs: 1, MaxArgs: 1, Supported: true},
-		CmdRun:        CommandMeta{Name: CmdRun, MinArgs: 1, MaxArgs: 1, Supported: true},
+		CmdRun:        CommandMeta{Name: CmdRun, MinArgs: 1, MaxArgs: 2, Supported: true},
 		CmdWorkDir:    CommandMeta{Name: CmdWorkDir, MinArgs: 1, MaxArgs: 1, Supported: true},
 	}
 )

--- a/script/parser.go
+++ b/script/parser.go
@@ -161,26 +161,22 @@ func validateCmdArgs(cmdName string, args map[string]string) error {
 // split(rawArgs[n], ":") yields to a len(slice) < 2.
 func mapArgs(rawArgs string) (map[string]string, error) {
 	argMap := make(map[string]string)
+
+	// split params: param0:<param-val0> paramN:<param-valN> badparam
 	params, err := wordSplit(rawArgs)
 	if err != nil {
 		return nil, err
 	}
 
+	// for each, split pram:<pram-value> into {param, <param-val>}
 	for _, param := range params {
 		parts := paramSep.Split(param, 2)
 		if len(parts) != 2 {
 			return argMap, fmt.Errorf("invalid param: %s", param)
 		}
-
 		name := parts[0]
-
-		// safely remove start/end quotes
-		val, err := wordSplit(parts[1])
-		if err != nil {
-			return nil, err
-		}
-
-		argMap[name] = val[0]
+		val := trimQuotes(parts[1])
+		argMap[name] = val
 	}
 
 	return argMap, nil
@@ -264,6 +260,7 @@ func enforceDefaults(script *Script) (*Script, error) {
 }
 
 func cmdParse(cmdStr string) (cmd string, args []string, err error) {
+	logrus.Debugf("Parsing: %s", cmdStr)
 	args, err = wordSplit(cmdStr)
 	if err != nil {
 		return "", nil, err

--- a/script/words_split.go
+++ b/script/words_split.go
@@ -2,6 +2,7 @@ package script
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"strings"
 	"unicode"
@@ -106,4 +107,48 @@ func isQuote(r rune) bool {
 
 func isChar(r rune) bool {
 	return !isQuote(r) && !unicode.IsSpace(r)
+}
+
+func quote(str string) string {
+	if strings.Index(str, `'`) > -1 {
+		return doubleQuote(str)
+	}
+	if strings.Index(str, `"`) > -1 {
+		return singleQuote(str)
+	}
+	return doubleQuote(str)
+}
+
+func doubleQuote(val string) string {
+	return fmt.Sprintf(`"%s"`, val)
+}
+
+func singleQuote(val string) string {
+	return fmt.Sprintf(`'%s'`, val)
+}
+
+func isQuoted(val string) bool {
+	single := `'`
+	dbl := `"`
+	if strings.HasPrefix(val, single) && strings.HasSuffix(val, single) {
+		return true
+	}
+	if strings.HasPrefix(val, dbl) && strings.HasSuffix(val, dbl) {
+		return true
+	}
+	return false
+}
+
+func trimQuotes(val string) string {
+	single := `'`
+	dbl := `"`
+
+	if strings.HasPrefix(val, single) || strings.HasPrefix(val, dbl) {
+		val = strings.TrimPrefix(val, val[0:1])
+	}
+	if strings.HasSuffix(val, single) || strings.HasSuffix(val, dbl) {
+		val = strings.TrimSuffix(val, val[len(val)-1:len(val)])
+	}
+
+	return val
 }

--- a/script/words_split_test.go
+++ b/script/words_split_test.go
@@ -49,9 +49,19 @@ func TestWordSplit(t *testing.T) {
 			words: []string{"aaa", `"bbb ccc"`, "ddd"},
 		},
 		{
-			name:  "embedded quoted runins",
+			name:  "embedded double quotes runins",
 			str:   `aaa'"bbb ccc"' ddd`,
 			words: []string{`aaa'"bbb ccc"'`, "ddd"},
+		},
+		{
+			name:  "embedded single quotes runins",
+			str:   `aaa"bbb 'ccc'" ddd`,
+			words: []string{`aaa"bbb 'ccc'"`, "ddd"},
+		},
+		{
+			name:  "actual exec command",
+			str:   `/bin/bash -c 'echo "Hello World"'`,
+			words: []string{`/bin/bash`, `-c`, `echo "Hello World"`},
 		},
 	}
 
@@ -68,6 +78,69 @@ func TestWordSplit(t *testing.T) {
 				if words[i] != test.words[i] {
 					t.Errorf("word mistached:\ngot %#v\nwant %#v", words, test.words)
 				}
+			}
+		})
+	}
+}
+
+func TestWordSplitTrimQuotes(t *testing.T) {
+	tests := []struct {
+		name   string
+		str    string
+		result string
+	}{
+		{
+			name:   "balanced double quote",
+			str:    `"aa bb cc dd"`,
+			result: "aa bb cc dd",
+		},
+		{
+			name:   "balanced single quote",
+			str:    `'aa bb cc dd'`,
+			result: "aa bb cc dd",
+		},
+		{
+			name:   "balanced double with embedded single",
+			str:    `"aa 'bb cc' dd"`,
+			result: "aa 'bb cc' dd",
+		},
+		{
+			name:   "balanced single with embedded double",
+			str:    `'"aa bb" cc dd'`,
+			result: `"aa bb" cc dd`,
+		},
+		{
+			name:   "balanced single with embedded singles",
+			str:    `''aa bb cc' dd'`,
+			result: `'aa bb cc' dd`,
+		},
+		{
+			name:   "unbalanced singles with embedded singles",
+			str:    `aa bb cc' dd'`,
+			result: `aa bb cc' dd`,
+		},
+		{
+			name:   "unbalanced singles with embedded doubles",
+			str:    `'aa "bb cc" dd`,
+			result: `aa "bb cc" dd`,
+		},
+		{
+			name:   "unbalanced double with embedded singles",
+			str:    `aa 'bb cc' dd"`,
+			result: `aa 'bb cc' dd`,
+		},
+		{
+			name:   "unbalanced double with embedded doubles",
+			str:    `"aa "bb cc" dd`,
+			result: `aa "bb cc" dd`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := trimQuotes(test.str)
+			if result != test.result {
+				t.Fatalf("unexpected result: want %v, got %v", test.result, result)
 			}
 		})
 	}

--- a/ssh/client.go
+++ b/ssh/client.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -76,9 +75,8 @@ func (c *SSHClient) Dial(addr string) error {
 }
 
 // SSHRun executes the specified command on a remote host over SSH
-func (c *SSHClient) SSHRun(cmd string, args ...string) (io.Reader, error) {
-	cmdStr := strings.TrimSpace(fmt.Sprintf("%s %s", cmd, strings.Join(args, " ")))
-	logrus.Debug("Running remote command: ", cmdStr)
+func (c *SSHClient) SSHRun(cmdStr string) (io.Reader, error) {
+	logrus.Debug("SSHRun: ", cmdStr)
 	session, err := c.sshc.NewSession()
 	if err != nil {
 		return nil, err

--- a/ssh/client_test.go
+++ b/ssh/client_test.go
@@ -84,7 +84,7 @@ func TestSSHClient(t *testing.T) {
 				}
 				defer sshClient.Hangup()
 
-				reader, err := sshClient.SSHRun("echo", "Hello!")
+				reader, err := sshClient.SSHRun("echo 'Hello World!'")
 				if err != nil {
 					return err
 				}
@@ -93,7 +93,7 @@ func TestSSHClient(t *testing.T) {
 					return err
 				}
 
-				if strings.TrimSpace(buff.String()) != "Hello!" {
+				if strings.TrimSpace(buff.String()) != "Hello World!" {
 					t.Fatal("SSHRun unexpected result: ", buff.String())
 				}
 				return nil
@@ -110,7 +110,7 @@ func TestSSHClient(t *testing.T) {
 				}
 				defer sshClient.Hangup()
 
-				if _, err := sshClient.SSHRun("foo", "bar"); err != nil {
+				if _, err := sshClient.SSHRun("foo bar"); err != nil {
 					return err
 				}
 


### PR DESCRIPTION
This PR fixes quoting issues with DIRECTIVES which take shell commands.
The code changes can handle many scenarios including:
* `{RUN | CAPTURE} echo "Hello World!"`
* `{RUN | CAPTURE} "echo 'Hello World!'"`
* `{RUN | CAPTURE} 'echo "Hello World"'`
* `{RUN | CAPTURE} "/bin/sh -c 'date -u'"`
* `{RUN | CAPTURE} /bin/bash -c 'echo "Hello World"'`
* `{RUN | CAPTURE} shell:"/bin/bash -c" cmd:"echo 'HELLO WORLD'"`

This PR fixes #23 