### PR TITLE
Support for Variable Expansion Escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,142 @@
 # Changelog
+## v0.1.0
+This is the first release of the project.  It marks the end of the 0.1.0-alpha.x release series designed to get the project to a stable and usable place.  It includes the following high level features:
+
+* Support for diagnostics script file
+* Support for several directive commands including RUN, COPY, CAPTURE, etc
+* Flexible script directive format with support fro nested quotes for complex shell commands
+* Script supports environment variable declaration with variable expansion
+* Ability to execute diagnostics script commands on remote machines
+* Automatically collect and collate script result as a tar file
+* Etc
+
+See the [README](https://github.com/vmware-tanzu/crash-diagnostics/blob/master/README.md) for feature detail.
+
+#### Changelog
+
+79322fa Merge pull request #28 from vladimirvivien/v0.1.0-release
+8a0d801 v0.1.0 Release and doc update
+32e599b Merge pull request #27 from vladimirvivien/release-v0.1.0
+7124db5 v0.1.0 release doc updates
+
+## v0.1.0-alpha.9
+This is a fix release that corrects the way directives such as `RUN` and `CAPTURE` handle embedded quotes (see issue #23 for detail).  This release also adds the `shell:` named param to `RUN` and `CAPTURE` to specify a shell program to use to wrap a given command.  So now the followings are supported for these two actions (note the way quotes can now be embedded):
+
+* `{RUN | CAPTURE} echo "Hello World!"`
+* `{RUN | CAPTURE} "echo 'Hello World!'"`
+* `{RUN | CAPTURE} 'echo "Hello World"'`
+* `{RUN | CAPTURE} "/bin/sh -c 'date -u'"`
+* `{RUN | CAPTURE} /bin/bash -c 'echo "Hello World"'`
+* `{RUN | CAPTURE} cmd:"echo 'HELLO WORLD'"`
+* `{RUN | CAPTURE} shell:"/bin/bash -c" cmd:"echo 'HELLO WORLD'"`
+
+#### Changelog
+264a134 Merge pull request #25 from vladimirvivien/quote-bug-fix
+88071f2 Changes and tests for quoted SSH commands
+bf355da Executor test updates to handle embedded quotes
+e9b93ec Script parser updates to handle embeded quotes
+dac401b Merge pull request #22 from YanzhaoLi/topic/fix-run-error-info
+fd7e470 Change Run command's error info
+
+
+## v0.1.0-alpha.8
+This release introduces the new `RUN` directive to execute commands on remote machines without capturing the output in the generated archive file like `CAPTURE`.  This is useful help interact with the remote nodes for tasks such as data preparation such as the following example:
+
+```
+# gather logs
+RUN mkdir -p /tmp/all-logs
+RUN cp /var/log/containers/* /tmp/all-logs 
+RUN cp /var/log/kube-apiserver.log /tmp/all-logs
+RUN cp /var/log/kubelet.log /tmp/all-logs
+RUN cp /var/log/kube-proxy.log /tmp/all-logs
+
+# copy all logs
+COPY /tmp/all-logs
+
+# clean up
+RUN /usr/bin/rm -rf /tmp/all-logs
+```
+
+#### Changelog
+e2a9055 Merge pull request #19 from vladimirvivien/run-command-support
+1cd6097 Documentation updates for RUN command
+f8442b3 Executor updates for RUN command
+64d62a5 Parser updates for RUN command
+
+
+## v0.1.0-alhpa.7
+This release introduces Unix-style variable expansion in Diagnostics.file script.  The previous `Go-style` templating has been `deprecated`  in favor of the more traditional variable expansion.
+
+## Variable Expansion
+Now all directives that appear in the Diagnostic script file can support variable expansion. This provides a more familiar feel to those with experience writing shell script.  For instance, the following shows how variable expansion can be used in a Diagnostics script:
+
+```
+ENV clogs=/var/log/containers
+ENV klogroot=/var/log
+COPY ${clogs}
+COPY $klogroot/kubelet.log
+COPY ${klogroot}/kube-proxy.log
+COPY ${klogroot}/kube-apiserver.log
+```
+
+Diagnostics script files can also access any environment variables made available to the process at runtime:
+```
+FROM 127.0.0.1:22
+AUTHCONFIG username:${USER} private-key:${HOME}/.ssh/id_rsa
+CAPTURE /bin/echo "HELLO WORLD"
+```
+
+#### Changelog
+e64ccca Merge pull request #18 from vladimirvivien/var-expansion-redo
+43b2371 Documentation updates
+0621e2c Executor updates with var expansion support
+bfd2430 Parser update  with variable expansion support
+
+
+## v0.1.0-alpha.6
+This release introduces better more robust directive string parsing with support for quoted values.  With this release, the followings are possible:
+* `DIRECTIVE paramName:ParamValue` example: `WORKDIR path:/tmp/mypath`
+* `DIRECTIVE paramName:"paramValue"` example `OUTPUT path:"/tmp/my dir"`
+* `DIRECTIVE paramName:'value0 "value1"'`  example `CAPTURE cmd:'/bin/echo "Hello World!"'`
+
+Also most directive also support now a default parameter than can be specified without a parameter name which can also support quoted values:
+
+* `WORKDIR "/tmp/my dir"`
+* `ENV "key0=val0 key1=val1"`
+* Etc. (see documentation)
+
+#### Changelog
+647c71b Merge pull request #14 from vladimirvivien/quoted-cmd-parsing
+4c22fef Better command parsing, quoted value support
+
+
+## v0.1.0-alpha.5
+This release introduces a uniform way of specifying parameters for DIRECTIVEs in the Diagnostics.file.  Now, named parameters may be used to pass values into all directives.  See the README.
+
+#### Changelog
+5710199 Merge pull request #13 from vladimirvivien/uniform-directive-params
+3cfaf0c Update README doc
+ba3e873 exec package supports named params
+370d43a Parser updated to support named params
+22ac1fc Start refactoring for all commands
+
+
+## v0.1.0-alpha.4
+This release sets up automated build and release with goreleaser and travis
+No new features introduced.
+
+#### Changelog
+4b6c1b7 Merge pull request #8 from vladimirvivien/fix-travis-encrypt-val-parsing
+ba8fe45 Fix for encrypted env in travis
+b7eab26 Merge pull request #7 from vladimirvivien/travis-fix
+a239215 (origin/travis-fix) Fixing encrypted global var
+8ca1f57 Merge pull request #6 from vladimirvivien/release-automation-fix
+f76f5ff (origin/release-automation-fix) Fix to travis encrypted values
+81b4c23 Merge pull request #3 from vladimirvivien/release-automation
+8aa0fd0 (origin/release-automation) Build and release automation with travis, gorelaser
+0f6b3f8 Merge pull request #2 from vladimirvivien/automated-build
+9a0ef20 (origin/automated-build) Initial CI setup for automatic build/test
+
 
 ## v0.1.0-alpha.0 (10/2/2019)
 Initial release.
@@ -24,6 +162,8 @@ WORKDIR
 * See [README.md](README.md) for detail
 
 ## Previous changes
+
+#### Changelog
 e805951 (HEAD -> alpha.0-migration-doc, upstream/master, upstream/HEAD, update-author-info, master) Migration to GitHub/VMware-Tanzu
 bd4846e OSS compliance docs and updates
 2f70416 Naming refactor, fixes, and tests

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,16 +11,17 @@ These releases are meant to introduce new features and introduce fundamental des
 * Standardization - ensure that script directives are consistent and predictable for improved usability.
 * Feature growth - continue to improve on current features and add new ones.
 
-### Features
-* Go API - ensure a clear API surface for code reuse and embedding.
-* Pluggable executors - make executors (the code that executes the translated script directives) work using pluggable API (i.e. interface) 
-
 ## v0.2.x-Releases
 The 0.2.x releases will continue to provide stability of features introduced in previous release series (v0.1.0).  
 There will be two main themes in this release:
 * Introduction of new `KUBEGET` directive to query objects from the API server
 * Start a collection of Diagnostics files for troubleshooting recipes
 * Redesign the execution backend into a pluggable system allowing different execution runtime (i.e. SSH, HTTP, gRPC, cloud provider, etc)
+
+### Features
+The following additional features are also planned for this series.
+* Go API - ensure a clear API surface for code reuse and embedding.
+* Pluggable executors - make executors (the code that executes the translated script directives) work using pluggable API (i.e. interface) 
 
 
 ## v0.3.x-Releases

--- a/TODO.md
+++ b/TODO.md
@@ -40,6 +40,9 @@ This tag/version reflects migration to github
 
 # v0.1.1
 * [ ] Fix parameter expansion clash between tool parser and shell
+* [ ] Introduce ability to escape variable expansion
+* [ ] Update docs
+* [ ] Update changelog doc
 
 # v0.2.0-alpha.0
 * [ ] New directive `KUBEGET`

--- a/TODO.md
+++ b/TODO.md
@@ -35,8 +35,11 @@ This tag/version reflects migration to github
 * [x] Embedded quotes bug fix for `RUN` and `CAPTURE`
 
 # v0.1.0 Release
-* [ ] Doc udpdate
-* [ ] Todo and Roadmap updates
+* [x] Doc udpdate
+* [x] Todo and Roadmap updates
+
+# v0.1.1
+* [ ] Fix parameter expansion clash between tool parser and shell
 
 # v0.2.0-alpha.0
 * [ ] New directive `KUBEGET`

--- a/exec/env_exec.go
+++ b/exec/env_exec.go
@@ -14,7 +14,7 @@ func exeEnvs(src *script.Script) error {
 	// for _, envCmd := range envCmds {
 	// 	cmd := envCmd.(*script.EnvCommand)
 	// 	for name, val := range cmd.Envs() {
-	// 		if err := os.Setenv(name, os.ExpandEnv(val)); err != nil {
+	// 		if err := os.Setenv(name, script.ExpandEnv(val)); err != nil {
 	// 			return fmt.Errorf("ENV: %s", err)
 	// 		}
 	// 	}

--- a/exec/env_exec_test.go
+++ b/exec/env_exec_test.go
@@ -66,7 +66,7 @@ func TestExecENV(t *testing.T) {
 				if os.Getenv("TEST_B") != "1" {
 					t.Errorf("unexpected ENV TEST_B value: %s", os.Getenv("TEST_B"))
 				}
-				if os.Getenv("TEST_C") != os.ExpandEnv("${USER}") {
+				if os.Getenv("TEST_C") != script.ExpandEnv("${USER}") {
 					t.Errorf("unexpected ENV TEST_C value: %s", os.Getenv("TEST_C"))
 				}
 				return nil

--- a/exec/run_exec_test.go
+++ b/exec/run_exec_test.go
@@ -185,6 +185,25 @@ func TestExecLocalRUN(t *testing.T) {
 				return nil
 			},
 		},
+		{
+			name: "RUN with escaped var expansion",
+			source: func() string {
+				return `
+				ENV MSG="Hello"
+				RUN /bin/bash -c 'msg="$MSG World!" && echo \$msg'`
+			},
+			exec: func(s *script.Script) error {
+				e := New(s)
+				if err := e.Execute(); err != nil {
+					return err
+				}
+				result := os.Getenv("CMD_RESULT")
+				if strings.TrimSpace(result) != "Hello World!" {
+					return fmt.Errorf("RUN has unexpected CMD_RESULT: %s", result)
+				}
+				return nil
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/script/as_cmd.go
+++ b/script/as_cmd.go
@@ -64,12 +64,12 @@ func (c *AsCommand) Args() map[string]string {
 
 // GetUserId returns the userid specified in AS
 func (c *AsCommand) GetUserId() string {
-	return os.ExpandEnv(c.cmd.args["userid"])
+	return ExpandEnv(c.cmd.args["userid"])
 }
 
 // GetGroupId returns the gid specified in AS
 func (c *AsCommand) GetGroupId() string {
-	return os.ExpandEnv(c.cmd.args["groupid"])
+	return ExpandEnv(c.cmd.args["groupid"])
 }
 
 // GetCredentials returns the uid and gid value extracted from Args

--- a/script/as_cmd_test.go
+++ b/script/as_cmd_test.go
@@ -133,7 +133,7 @@ func TestCommandAS(t *testing.T) {
 			script: func(s *Script) error {
 				cmds := s.Preambles[CmdAs]
 				asCmd := cmds[0].(*AsCommand)
-				if asCmd.GetUserId() != os.ExpandEnv("$USER") {
+				if asCmd.GetUserId() != ExpandEnv("$USER") {
 					return fmt.Errorf("Unexpected AS userid %s", asCmd.GetUserId())
 				}
 				if asCmd.GetGroupId() != "barid" {

--- a/script/authconfig_cmd.go
+++ b/script/authconfig_cmd.go
@@ -5,7 +5,6 @@ package script
 
 import (
 	"fmt"
-	"os"
 )
 
 // AuthConfigCommand represents AUTHCONFIG directive:
@@ -53,10 +52,10 @@ func (c *AuthConfigCommand) Args() map[string]string {
 
 // GetPrivateKey returns the path of the private key configured
 func (c *AuthConfigCommand) GetPrivateKey() string {
-	return os.ExpandEnv(c.cmd.args["private-key"])
+	return ExpandEnv(c.cmd.args["private-key"])
 }
 
 // GetUsername returns the User ID configured
 func (c *AuthConfigCommand) GetUsername() string {
-	return os.ExpandEnv(c.cmd.args["username"])
+	return ExpandEnv(c.cmd.args["username"])
 }

--- a/script/authconfig_cmd_test.go
+++ b/script/authconfig_cmd_test.go
@@ -89,7 +89,7 @@ func TestCommandAUTHCONFIG(t *testing.T) {
 			script: func(s *Script) error {
 				cmds := s.Preambles[CmdAuthConfig]
 				authCmd := cmds[0].(*AuthConfigCommand)
-				if authCmd.GetUsername() != os.ExpandEnv("$USER") {
+				if authCmd.GetUsername() != ExpandEnv("$USER") {
 					return fmt.Errorf("Unexpected username %s", authCmd.GetUsername())
 				}
 				if authCmd.GetPrivateKey() != "/a/b/c" {

--- a/script/copy_cmd.go
+++ b/script/copy_cmd.go
@@ -5,7 +5,6 @@ package script
 
 import (
 	"fmt"
-	"os"
 )
 
 // CopyCommand represents a COPY directive which may have
@@ -60,7 +59,7 @@ func (c *CopyCommand) Name() string {
 func (c *CopyCommand) Paths() []string {
 	paths := []string{}
 	for _, path := range spaceSep.Split(c.cmd.args["paths"], -1) {
-		paths = append(paths, os.ExpandEnv(path))
+		paths = append(paths, ExpandEnv(path))
 	}
 	return paths
 }

--- a/script/env_cmd.go
+++ b/script/env_cmd.go
@@ -71,8 +71,8 @@ func NewEnvCommand(index int, rawArgs string) (*EnvCommand, error) {
 		}
 		value := val[0]
 
-		cmd.envs[key] = os.ExpandEnv(value)
-		if err := os.Setenv(key, os.ExpandEnv(value)); err != nil {
+		cmd.envs[key] = ExpandEnv(value)
+		if err := os.Setenv(key, ExpandEnv(value)); err != nil {
 			return nil, fmt.Errorf("ENV: %s", err)
 		}
 	}

--- a/script/env_exapand.go
+++ b/script/env_exapand.go
@@ -1,0 +1,215 @@
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package script
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"strings"
+	"unicode"
+)
+
+// runeStack is a super simple stack (with slice backing) used to keep track
+// of special boundary characters.
+type runeStack struct {
+	store []rune
+	top   int
+}
+
+func newRuneStack() *runeStack {
+	return &runeStack{store: []rune{}, top: -1}
+}
+
+func (r *runeStack) push(val rune) {
+	r.top++
+	if r.top > len(r.store)-1 {
+		r.store = append(r.store, val)
+	} else {
+		r.store[r.top] = val
+	}
+}
+
+func (r *runeStack) pop() rune {
+	if r.isEmpty() {
+		return 0
+	}
+	val := r.store[r.top]
+	r.top--
+	return val
+}
+
+func (r *runeStack) peek() rune {
+	if r.isEmpty() {
+		return 0
+	}
+	return r.store[r.top]
+}
+
+func (r *runeStack) isEmpty() bool {
+	return (r.top < 0)
+}
+
+func (r *runeStack) depth() int {
+	return r.top + 1
+}
+
+// ExpandEnv searches str for $value or ${value} which is then evaluated
+// using os.ExpandEnv. expandVar supports escaping expansion using \$. For instance,
+// when \$value or \${value} is encountered, it is not expanded, leaving the original
+// values in the string as $value or ${value}.
+func ExpandEnv(str string) string {
+	stack := newRuneStack()
+	rdr := bufio.NewReader(strings.NewReader(str))
+	var result strings.Builder
+	var variable strings.Builder
+
+	inVar := false
+	//inEscape := false
+
+	// The algorithm is simple:
+	// a) when boundary char \ or $ is encountered: push onto stack
+	// b) (escape) if stack.top = \ and $ is encountered, skip slash, pop all items and $ unto result string
+	// c) if in scape write all subsequent chars in result (except \ prefix) until/including space char or end of string
+	// d) if inVar ($ followed by nonspace), save all subsequent char in variable until a space char or end of string
+	for {
+		token, _, err := rdr.ReadRune()
+		if err != nil {
+			// resolve outstanding vars and save dangling slashes/dollar signs at EOF
+			if err == io.EOF {
+				popAll(&result, stack)
+				if inVar {
+					result.WriteString(resloveVar(&variable))
+				}
+			}
+			return result.String()
+		}
+
+		switch {
+		// save '\' on stack for later
+		case isBackSlash(token):
+			stack.push(token)
+
+		// if '$':
+		// 1) if stack.top = '\', escape
+		// 2) else save on stack
+		case isDollarSign(token):
+			if isBackSlash(stack.peek()) {
+				stack.pop()
+				popAll(&result, stack)
+				result.WriteRune(token)
+				continue
+			}
+			stack.push(token)
+
+		// if '{':
+		// if stack.top = '$', start of ${variable}
+		// else write token unto result
+		case isOpenCurly(token):
+			if isDollarSign(stack.peek()) {
+				inVar = true
+				variable.WriteRune(stack.pop())
+				popAll(&result, stack)
+				variable.WriteRune(token)
+				continue
+			}
+			result.WriteRune(token)
+
+		// handle all other chars
+		default:
+			switch {
+			// if '}':
+			// if in var, assume var boundary, resolve/save var in result str
+			// else, save token in result srt
+			case isCloseCurly(token):
+				if inVar {
+					inVar = false
+					variable.WriteRune(token)
+					result.WriteString(resloveVar(&variable))
+					continue
+				}
+				result.WriteRune(token)
+
+			// if token is boundary (space, punctuations, symbols, etc):
+			// 1) if in var, assume var boundary resolve/save var in result str
+			// 2) or, write tokens to result string
+			case isBoundary(token):
+				if inVar {
+					inVar = false
+					result.WriteString(resloveVar(&variable))
+					result.WriteRune(token)
+					continue
+				}
+				popAll(&result, stack)
+				result.WriteRune(token)
+
+			// if letter:
+			// 1) if in var, save var name
+			// 2) if stack.top = '$', assume start of var
+			// 3) otherwise write token in result
+			default:
+				if inVar {
+					variable.WriteRune(token)
+					continue
+				}
+
+				if isDollarSign(stack.peek()) {
+					inVar = true
+					variable.WriteRune(stack.pop())
+					variable.WriteRune(token)
+					continue
+				}
+
+				popAll(&result, stack)
+				result.WriteRune(token)
+			}
+		}
+	}
+}
+
+func isDollarSign(r rune) bool {
+	if r == '$' {
+		return true
+	}
+	return false
+}
+
+func isBackSlash(r rune) bool {
+	if r == '\\' {
+		return true
+	}
+	return false
+}
+
+func isOpenCurly(r rune) bool {
+	if r == '{' {
+		return true
+	}
+	return false
+}
+func isCloseCurly(r rune) bool {
+	if r == '}' {
+		return true
+	}
+	return false
+}
+func popAll(target *strings.Builder, stack *runeStack) {
+	for !stack.isEmpty() {
+		target.WriteRune(stack.pop())
+	}
+}
+
+func resloveVar(variable *strings.Builder) string {
+	val := variable.String()
+	variable.Reset()
+	return os.ExpandEnv(val)
+}
+
+func isBoundary(token rune) bool {
+	switch {
+	case unicode.IsSpace(token), token == ':', token == '#', token == '%':
+		return true
+	}
+	return false
+}

--- a/script/env_expand_test.go
+++ b/script/env_expand_test.go
@@ -1,0 +1,348 @@
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package script
+
+import (
+	"os"
+	"testing"
+)
+
+func TestExpandVarStack(t *testing.T) {
+	tests := []struct {
+		name  string
+		stack func() *runeStack
+		test  func(*runeStack)
+	}{
+		{
+			name: "push/pop",
+			stack: func() *runeStack {
+				s := newRuneStack()
+				s.push('a')
+				s.push('b')
+				s.pop()
+				s.push('$')
+				return s
+			},
+			test: func(s *runeStack) {
+				if s.depth() != 2 {
+					t.Errorf("unexpected stack depth: %d", s.depth())
+				}
+			},
+		},
+		{
+			name: "push/pop/peek",
+			stack: func() *runeStack {
+				s := newRuneStack()
+				s.push('a')
+				s.push('b')
+				s.push('$')
+				s.push('\\')
+				s.pop()
+				return s
+			},
+			test: func(s *runeStack) {
+				if s.depth() != 3 {
+					t.Errorf("unexpected stack depth: %d", s.depth())
+				}
+				if s.peek() != '$' {
+					t.Errorf("unexpected stack.peek value: %s", string(s.peek()))
+				}
+			},
+		},
+		{
+			name: "push/pop/isempty",
+			stack: func() *runeStack {
+				s := newRuneStack()
+				s.push('a')
+				s.push('b')
+				s.pop()
+				s.pop()
+				s.pop()
+				return s
+			},
+			test: func(s *runeStack) {
+				if s.depth() != 0 {
+					t.Errorf("unexpected stack.depth: %d", s.depth())
+				}
+				if !s.isEmpty() {
+					t.Errorf("unexpected stack.empty status: %t", s.isEmpty())
+				}
+				if s.peek() != 0 {
+					t.Errorf("unexpected stack.peek value: %s", string(s.peek()))
+				}
+			},
+		},
+		{
+			name: "push/pop/isempty",
+			stack: func() *runeStack {
+				s := newRuneStack()
+				s.push('a')
+				s.push('b')
+				s.pop()
+				s.pop()
+				s.pop()
+				s.push('c')
+				s.push('d')
+				return s
+			},
+			test: func(s *runeStack) {
+				if s.depth() != 2 {
+					t.Errorf("unexpected stack.depth: %d", s.depth())
+				}
+				if s.isEmpty() {
+					t.Errorf("unexpected stack.empty status: %t", s.isEmpty())
+				}
+				if s.peek() != 'd' {
+					t.Errorf("unexpected stack.peek value: %s", string(s.peek()))
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.test(test.stack())
+		})
+	}
+}
+
+func TestExpandVar(t *testing.T) {
+	tests := []struct {
+		name     string
+		genStr   func() string
+		expected string
+	}{
+		{
+			name:     "no expansion",
+			genStr:   func() string { return " Hello, from the world!  " },
+			expected: " Hello, from the world!  ",
+		},
+		{
+			name:     `slash - all`,
+			genStr:   func() string { return `\\\\\ \\\ \\\` },
+			expected: `\\\\\ \\\ \\\`,
+		},
+		{
+			name:     `slash - single middle`,
+			genStr:   func() string { return `this \ that` },
+			expected: `this \ that`,
+		},
+		{
+			name:     `slash - single end of word`,
+			genStr:   func() string { return `this\ that` },
+			expected: `this\ that`,
+		},
+		{
+			name:     `slash - single start word`,
+			genStr:   func() string { return `this \that` },
+			expected: `this \that`,
+		},
+		{
+			name:     `slash - single start of string`,
+			genStr:   func() string { return `\this that` },
+			expected: `\this that`,
+		},
+		{
+			name:     `slash - single end of string`,
+			genStr:   func() string { return `this that\` },
+			expected: `this that\`,
+		},
+		{
+			name:     `slash - single inside single word`,
+			genStr:   func() string { return `this\that` },
+			expected: `this\that`,
+		},
+		{
+			name:     `slash - single inside multi words`,
+			genStr:   func() string { return `this w\t t\at` },
+			expected: `this w\t t\at`,
+		},
+		{
+			name:     `slash - multi inside single word`,
+			genStr:   func() string { return `t\\s that` },
+			expected: `t\\s that`,
+		},
+		{
+			name:     `slash - multi inside multi words`,
+			genStr:   func() string { return `t\\s t\ha\t` },
+			expected: `t\\s t\ha\t`,
+		},
+		{
+			name:     `slash - multi start word`,
+			genStr:   func() string { return `this \\\\that` },
+			expected: `this \\\\that`,
+		},
+		{
+			name:     `slash - multi middle`,
+			genStr:   func() string { return `this \\\\ that` },
+			expected: `this \\\\ that`,
+		},
+		{
+			name:     `slash - multi end of word`,
+			genStr:   func() string { return `this\\\ that` },
+			expected: `this\\\ that`,
+		},
+		{
+			name:     `slash - multi start of string`,
+			genStr:   func() string { return `\\\this that` },
+			expected: `\\\this that`,
+		},
+		{
+			name:     `slash - multi start of string`,
+			genStr:   func() string { return `this that\\\` },
+			expected: `this that\\\`,
+		},
+		{
+			name:     `slash - multi inside single word`,
+			genStr:   func() string { return `this\\\that` },
+			expected: `this\\\that`,
+		},
+		{
+			name:     `escape - start of string`,
+			genStr:   func() string { return `\$this that` },
+			expected: `$this that`,
+		},
+		{
+			name:     `escape - middle of string`,
+			genStr:   func() string { return `this \$is that` },
+			expected: `this $is that`,
+		},
+		{
+			name:     `escape - end of string`,
+			genStr:   func() string { return `this \$that` },
+			expected: `this $that`,
+		},
+		{
+			name:     `escape - with slash at start of string`,
+			genStr:   func() string { return `thi\s\ \$that` },
+			expected: `thi\s\ $that`,
+		},
+		{
+			name:     `escape - with slash at end of string`,
+			genStr:   func() string { return `\$this th\at\` },
+			expected: `$this th\at\`,
+		},
+		{
+			name:     `escape - embedded`,
+			genStr:   func() string { return `this\$isthat` },
+			expected: `this$isthat`,
+		},
+		{
+			name:     `escape - curly vars`,
+			genStr:   func() string { return `this \${is} that` },
+			expected: `this ${is} that`,
+		},
+		{
+			name:     `escape - curly vars embedded`,
+			genStr:   func() string { return `this\${is}that or other` },
+			expected: `this${is}that or other`,
+		},
+		{
+			name:     `dollar - all`,
+			genStr:   func() string { return `$$$$$ $$ $$$` },
+			expected: `$$$$$ $$ $$$`,
+		},
+		{
+			name:     `dollar - single middle`,
+			genStr:   func() string { return `foo $ bar` },
+			expected: `foo $ bar`,
+		},
+		{
+			name:     `dollar - single end of word`,
+			genStr:   func() string { return `foo$ bar` },
+			expected: `foo$ bar`,
+		},
+		{
+			name:     `dollar - single end of string`,
+			genStr:   func() string { return `foo$ bar$` },
+			expected: `foo$ bar$`,
+		},
+		{
+			name:     `var - undeclared var`,
+			genStr:   func() string { return `foo $bar` },
+			expected: `foo `,
+		},
+		{
+			name: `var - declared at start of string`,
+			genStr: func() string {
+				os.Setenv("foo", "boo")
+				return `$foo bar`
+			},
+			expected: `boo bar`,
+		},
+		{
+			name: `var - declared at end of string`,
+			genStr: func() string {
+				os.Setenv("bar", "zaar")
+				return `foo $bar`
+			},
+			expected: `foo zaar`,
+		},
+		{
+			name: `var - embedded`,
+			genStr: func() string {
+				os.Setenv("bar", "zaar")
+				return `foo:$bar:cat`
+			},
+			expected: `foo:zaar:cat`,
+		},
+		{
+			name: `var - multi embedded`,
+			genStr: func() string {
+				os.Setenv("bar", "zaar")
+				return `foo:$bar:cat:$tar`
+			},
+			expected: `foo:zaar:cat:`,
+		},
+		{
+			name: `var - multiple declared vars`,
+			genStr: func() string {
+				os.Setenv("bar", "zaar")
+				os.Setenv("bazz", "raaz")
+				return `foo $bar with $bazz`
+			},
+			expected: `foo zaar with raaz`,
+		},
+		{
+			name: `var - multiple declared with missing vars`,
+			genStr: func() string {
+				os.Setenv("bar", "zaar")
+				os.Setenv("bazz", "raaz")
+				return `foo ${bar} with $bazz at ${jazz}`
+			},
+			expected: `foo zaar with raaz at `,
+		},
+		{
+			name: `var - curl vars embedded in words`,
+			genStr: func() string {
+				os.Setenv("bar", "zaar")
+				os.Setenv("bazz", "raaz")
+				return `foo${bar}with $bazz at ${jazz}`
+			},
+			expected: `foozaarwith raaz at `,
+		},
+		{
+			name:     `var - in dollar amount`,
+			genStr:   func() string { return `foo $120.00` },
+			expected: `foo 20.00`,
+		},
+		{
+			name: `all`,
+			genStr: func() string {
+				os.Setenv("DIR", "/var/logs")
+				return `/bin/bash -c 'files=\$(sudo find $DIR); for f in \$files; do cat \$f; done'`
+			},
+			expected: `/bin/bash -c 'files=$(sudo find /var/logs); for f in $files; do cat $f; done'`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := ExpandEnv(test.genStr())
+			if result != test.expected {
+				t.Errorf("unexpected expanded result: %s", result)
+			}
+		})
+	}
+}

--- a/script/from_cmd.go
+++ b/script/from_cmd.go
@@ -6,7 +6,6 @@ package script
 import (
 	"fmt"
 	"net"
-	"os"
 	"strings"
 )
 
@@ -80,7 +79,7 @@ func NewFromCommand(index int, rawArgs string) (*FromCommand, error) {
 
 	// populate machine representations
 	for _, host := range spaceSep.Split(argMap["hosts"], -1) {
-		addrVal := os.ExpandEnv(host)
+		addrVal := ExpandEnv(host)
 		cmd.machines = append(cmd.machines, *NewMachine(addrVal))
 	}
 

--- a/script/kubecfg_cmd.go
+++ b/script/kubecfg_cmd.go
@@ -5,7 +5,6 @@ package script
 
 import (
 	"fmt"
-	"os"
 )
 
 // KubeConfigCommand represents a KUBECONFIG directive which can have
@@ -57,7 +56,7 @@ func (c *KubeConfigCommand) Args() map[string]string {
 
 // Config returns the path to the config file
 func (c *KubeConfigCommand) Path() string {
-	return os.ExpandEnv(c.cmd.args["path"])
+	return ExpandEnv(c.cmd.args["path"])
 }
 
 // searchForConfig searches in several places for

--- a/script/output_cmd.go
+++ b/script/output_cmd.go
@@ -5,7 +5,6 @@ package script
 
 import (
 	"fmt"
-	"os"
 )
 
 // OutputCommand representes a OUTPUT directive which can have
@@ -56,5 +55,5 @@ func (c *OutputCommand) Args() map[string]string {
 
 // Path returns the parsed path for directory
 func (c *OutputCommand) Path() string {
-	return os.ExpandEnv(c.cmd.args["path"])
+	return ExpandEnv(c.cmd.args["path"])
 }

--- a/script/run_cmd.go
+++ b/script/run_cmd.go
@@ -5,7 +5,6 @@ package script
 
 import (
 	"fmt"
-	"os"
 )
 
 // RunCommand represents RUN directive which
@@ -69,12 +68,12 @@ func (c *RunCommand) Args() map[string]string {
 // GetCmdShell returns shell program and arguments
 // for running the command string (i.e. /bin/bash -c)
 func (c *RunCommand) GetCmdShell() string {
-	return os.ExpandEnv(c.cmd.args["shell"])
+	return ExpandEnv(c.cmd.args["shell"])
 }
 
 // GetCmdString returns the raw CLI command string
 func (c *RunCommand) GetCmdString() string {
-	return os.ExpandEnv(c.cmd.args["cmd"])
+	return ExpandEnv(c.cmd.args["cmd"])
 }
 
 // GetEffectiveCmd returns the shell (if any) and command as

--- a/script/workdir_cmd.go
+++ b/script/workdir_cmd.go
@@ -5,7 +5,6 @@ package script
 
 import (
 	"fmt"
-	"os"
 )
 
 // WorkdirCommand representes a WORKDIR which may have one
@@ -58,5 +57,5 @@ func (c *WorkdirCommand) Args() map[string]string {
 
 // Path returns the parsed path for directory
 func (c *WorkdirCommand) Path() string {
-	return os.ExpandEnv(c.cmd.args["path"])
+	return ExpandEnv(c.cmd.args["path"])
 }


### PR DESCRIPTION
This PR fixes issues with variable expansion by introducing support for expansion escape as shown below:
```
ENV bazz=buzz
foo \$bar $bazz
```
Produces
```
foo $bar buzz
```
Note `\$` allows escaping of expansion.

This will allow crash-diagnostics to skip variable expansion to avoid clashing with variable names to be sent to the server.

This PR fixes #26 
