### PR TITLE
Support file path globbing for COPY command

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -155,6 +155,12 @@ COPY paths:"/var/log/kube-proxy.log /var/log/containers"
 ```
 The previous command will copy file `/var/log/kube-proxy.log` and each file in directory `/var/log/containers` as part of the generated archive bundle.
 
+#### File name expansion
+The `COPY` command also supports file name expansion using patterns (or globbing).  For instance, the following will copy only log files whose names start with `kube` from the nodes:
+
+```
+COPY /var/log/kube*.log
+```
 
 ### ENV
 This directive is used to inject environment variables that are made available to other commands in the script file at runtime:

--- a/exec/cli.go
+++ b/exec/cli.go
@@ -26,7 +26,7 @@ func CliRun(uid, gid uint32, cmd string, args ...string) (io.Reader, error) {
 		os.Setenv("CMD_EXITCODE", fmt.Sprintf("%d", command.ProcessState.ExitCode()))
 		os.Setenv("CMD_PID", fmt.Sprintf("%d", command.ProcessState.Pid()))
 		os.Setenv("CMD_SUCCESS", fmt.Sprintf("%t", command.ProcessState.Success()))
-		return nil, err
+		return output, err
 	}
 
 	// save process info


### PR DESCRIPTION
This PR implements changes to support file path globbing when copying.  Now the followings will work:

```
COPY /var/log/kube-*.log
COPY $HOME/bin/*
```

This PR implements #16 