### PR TITLE
Implementing OUTPUT to support stdout

### DIFF
--- a/exec/executor.go
+++ b/exec/executor.go
@@ -74,9 +74,13 @@ func (e *Executor) Execute() error {
 			}
 		default:
 			for _, machine := range fromCmd.Machines() {
-				machineWorkdir, err := makeMachineWorkdir(workdir.Path(), machine)
-				if err != nil {
-					return err
+				machineWorkdir := "stdout"
+				if workdir.Path() != "stdout" {
+					wd, err := makeMachineWorkdir(workdir.Path(), machine)
+					if err != nil {
+						return err
+					}
+					machineWorkdir = wd
 				}
 
 				switch machine.Address() {
@@ -104,10 +108,12 @@ func (e *Executor) Execute() error {
 	}
 
 	// write result to output
-	if err := archiver.Tar(output.Path(), workdir.Path()); err != nil {
-		return err
+	if workdir.Path() != "stdout" {
+		if err := archiver.Tar(output.Path(), workdir.Path()); err != nil {
+			return err
+		}
+		logrus.Infof("Created output at path %s", output.Path())
 	}
-	logrus.Infof("Created output at path %s", output.Path())
 	logrus.Info("Done")
 
 	return nil

--- a/exec/support.go
+++ b/exec/support.go
@@ -5,11 +5,8 @@ package exec
 
 import (
 	"io"
-	"os"
 	"regexp"
 	"strings"
-
-	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -20,21 +17,14 @@ func sanitizeStr(cmd string) string {
 	return strSanitization.ReplaceAllString(cmd, "_")
 }
 
-func writeFile(source io.Reader, filePath string) error {
-	file, err := os.Create(filePath)
-	if err != nil {
+func writeFile(writer io.Writer, source io.Reader) error {
+	if _, err := io.Copy(writer, source); err != nil {
 		return err
 	}
-	defer file.Close()
-	if _, err := io.Copy(file, source); err != nil {
-		return err
-	}
-	logrus.Debugf("Wrote file %s", filePath)
-
 	return nil
 }
 
-func writeError(err error, filePath string) error {
+func writeError(writer io.Writer, err error) error {
 	errReader := strings.NewReader(err.Error())
-	return writeFile(errReader, filePath)
+	return writeFile(writer, errReader)
 }

--- a/exec/support.go
+++ b/exec/support.go
@@ -4,9 +4,14 @@
 package exec
 
 import (
+	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -27,4 +32,26 @@ func writeFile(writer io.Writer, source io.Reader) error {
 func writeError(writer io.Writer, err error) error {
 	errReader := strings.NewReader(err.Error())
 	return writeFile(writer, errReader)
+}
+
+func getFileForCaptureCmd(cmdStr, workdir, output string) (*os.File, error) {
+	var outfile *os.File
+	switch output {
+	case OutputStdout:
+		outfile = os.Stdout
+		logrus.Debugf("Routing result for [%s] to stdout", cmdStr)
+	case OutputStderr:
+		outfile = os.Stderr
+		logrus.Debugf("Routing result for [%s] to stderr", cmdStr)
+	default:
+		fileName := fmt.Sprintf("%s.txt", sanitizeStr(cmdStr))
+		filePath := filepath.Join(workdir, fileName)
+		logrus.Debugf("Creating file %s for [%s]", filePath, cmdStr)
+		f, err := os.Create(filePath)
+		if err != nil {
+			return nil, err
+		}
+		outfile = f
+	}
+	return outfile, nil
 }


### PR DESCRIPTION
This PR implements support for `OUTPUT stdout` which would pipe content to standard output instead of a file.

Implements #34 