### PR TITLE
Support for console output for RUN and CAPTURE

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -135,12 +135,21 @@ Or, with its named parameter `cmd:`:
 CAPTURE cmd:"/bin/journalctl -l -u kube-apiserver"
 ```
 
-### CAPTURE file names
+#### CAPTURE file names
 The captured output will be written to a file whose name is derived from the command string as follows:
 
 ```
 _bin_journalctl__l__u_kube-api-server.txt
 ```
+
+#### CAPTURE Echo output
+The CAPTURE command can also copy its result to standard output using the `echo` parameter:
+
+```
+CAPTURE cmd:"/bin/journalctl -l -u kube-apiserver" echo:"true"
+```
+
+Note that you have to use the named parameter format.
 
 ### COPY
 This directive specifies one or more files (and/or directories) as data sources that are copied
@@ -323,6 +332,15 @@ COPY /tmp/containers
 # clean up
 RUN /usr/bin/rm -rf /tmp/containers
 ```
+
+#### RUN Echo output
+The RUJN command can also copy its result to standard output using the `echo` parameter:
+
+```
+RUN cmd:"/bin/journalctl -l -u kube-apiserver" echo:"true"
+```
+
+Note that you have to use the named parameter format.
 
 ### WORKDIR
 In a Diagnostics.file, `WORKDIR` specifies the working directory used when building the archive bundle as shown in the following example:

--- a/exec/run_exec_test.go
+++ b/exec/run_exec_test.go
@@ -204,6 +204,24 @@ func TestExecLocalRUN(t *testing.T) {
 				return nil
 			},
 		},
+		{
+			name: "RUN with echo on",
+			source: func() string {
+				return `RUN cmd:"/bin/echo 'HELLO WORLD'" echo:"true"`
+			},
+			exec: func(s *script.Script) error {
+
+				e := New(s)
+				if err := e.Execute(); err != nil {
+					return err
+				}
+				result := os.Getenv("CMD_RESULT")
+				if result != "HELLO WORLD" {
+					return fmt.Errorf("RUN has unexpected CMD_RESULT: %s", result)
+				}
+				return nil
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -356,6 +374,28 @@ func TestExecRemoteRUN(t *testing.T) {
 
 				result := os.Getenv("CMD_RESULT")
 				if strings.TrimSpace(result) != "Hello World" {
+					return fmt.Errorf("RUN has unexpected CMD_RESULT: %s", result)
+				}
+				return nil
+			},
+		},
+		{
+			name: "RUN with echo on",
+			source: func() string {
+				return `FROM 127.0.0.1:22
+				AUTHCONFIG username:${USER} private-key:${HOME}/.ssh/id_rsa
+				RUN cmd:'/bin/echo "HELLO WORLD"' echo:"on"
+				`
+			},
+			exec: func(s *script.Script) error {
+
+				e := New(s)
+				if err := e.Execute(); err != nil {
+					return err
+				}
+
+				result := os.Getenv("CMD_RESULT")
+				if result != "HELLO WORLD" {
 					return fmt.Errorf("RUN has unexpected CMD_RESULT: %s", result)
 				}
 				return nil

--- a/exec/support.go
+++ b/exec/support.go
@@ -4,6 +4,7 @@
 package exec
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"regexp"
@@ -20,21 +21,31 @@ func sanitizeStr(cmd string) string {
 	return strSanitization.ReplaceAllString(cmd, "_")
 }
 
-func writeFile(source io.Reader, filePath string) error {
+func writeCmdOutput(source io.Reader, filePath string, echo bool, cmd string) error {
 	file, err := os.Create(filePath)
 	if err != nil {
 		return err
 	}
 	defer file.Close()
-	if _, err := io.Copy(file, source); err != nil {
+
+	reader := source
+	if echo {
+		fmt.Fprintf(file, "%s\n", cmd)
+		fmt.Fprintf(os.Stdout, "%s\n", cmd)
+
+		reader = io.TeeReader(source, os.Stdout)
+	}
+
+	if _, err := io.Copy(file, reader); err != nil {
 		return err
 	}
+
 	logrus.Debugf("Wrote file %s", filePath)
 
 	return nil
 }
 
-func writeError(err error, filePath string) error {
+func writeCmdError(err error, filePath string, cmdStr string) error {
 	errReader := strings.NewReader(err.Error())
-	return writeFile(errReader, filePath)
+	return writeCmdOutput(errReader, filePath, false, cmdStr)
 }

--- a/script/capture_cmd.go
+++ b/script/capture_cmd.go
@@ -59,3 +59,10 @@ func (c *CaptureCommand) GetEffectiveCmdStr() (string, error) {
 	}
 	return cmdStr, nil
 }
+
+// GetEcho returns the echo param for command. When
+// set to {yes|true|on} the result of the command will be
+// redirected to the stdout|stderr
+func (c *CaptureCommand) GetEcho() string {
+	return c.RunCommand.GetEcho()
+}

--- a/script/capture_cmd_test.go
+++ b/script/capture_cmd_test.go
@@ -232,10 +232,6 @@ func TestCommandCAPTURE(t *testing.T) {
 				}
 				cmd := s.Actions[0].(*CaptureCommand)
 				if cmd.Args()["cmd"] != cmd.GetCmdString() {
-					return fmt.Errorf("CAPTURE action with unexpected CLI string %s", cmd.GetCmdString())
-				}
-
-				if cmd.Args()["cmd"] != cmd.GetCmdString() {
 					return fmt.Errorf("CAPTURE action with unexpected command string %s", cmd.GetCmdString())
 				}
 				if cmd.Args()["shell"] != cmd.GetCmdShell() {
@@ -257,6 +253,28 @@ func TestCommandCAPTURE(t *testing.T) {
 				}
 				if cliArgs[1] != "echo 'HELLO WORLD'" {
 					return fmt.Errorf("CAPTURE has unexpected shell argument: expecting -c, got %s", cliArgs[0])
+				}
+				return nil
+			},
+		},
+		{
+			name: "CAPTURE with echo param",
+			source: func() string {
+				return `CAPTURE shell:"/bin/bash -c" cmd:"echo 'HELLO WORLD'" echo:"true"`
+			},
+			script: func(s *Script) error {
+				if len(s.Actions) != 1 {
+					return fmt.Errorf("Script has unexpected actions, needs %d", len(s.Actions))
+				}
+				cmd := s.Actions[0].(*CaptureCommand)
+				if cmd.Args()["cmd"] != cmd.GetCmdString() {
+					return fmt.Errorf("CAPTURE action with unexpected CLI string %s", cmd.GetCmdString())
+				}
+				if cmd.Args()["shell"] != cmd.GetCmdShell() {
+					return fmt.Errorf("CAPTURE action with unexpected shell %s", cmd.GetCmdShell())
+				}
+				if cmd.Args()["echo"] != cmd.GetEcho() {
+					return fmt.Errorf("CAPTURE action with unexpected echo param %s", cmd.GetCmdShell())
 				}
 				return nil
 			},

--- a/script/commands.go
+++ b/script/commands.go
@@ -55,14 +55,14 @@ var (
 	Cmds = map[string]CommandMeta{
 		CmdAs:         CommandMeta{Name: CmdAs, MinArgs: 1, MaxArgs: 2, Supported: true},
 		CmdAuthConfig: CommandMeta{Name: CmdAuthConfig, MinArgs: 1, MaxArgs: 3, Supported: true},
-		CmdCapture:    CommandMeta{Name: CmdCapture, MinArgs: 1, MaxArgs: 2, Supported: true},
+		CmdCapture:    CommandMeta{Name: CmdCapture, MinArgs: 1, MaxArgs: 3, Supported: true},
 		CmdCopy:       CommandMeta{Name: CmdCopy, MinArgs: 1, MaxArgs: -1, Supported: true},
 		CmdEnv:        CommandMeta{Name: CmdEnv, MinArgs: 1, MaxArgs: -1, Supported: true},
 		CmdFrom:       CommandMeta{Name: CmdFrom, MinArgs: 1, MaxArgs: -1, Supported: true},
 		CmdKubeConfig: CommandMeta{Name: CmdKubeConfig, MinArgs: 1, MaxArgs: 1, Supported: true},
 		CmdKubeGet:    CommandMeta{Name: CmdKubeGet, MinArgs: 1, MaxArgs: -1, Supported: true},
 		CmdOutput:     CommandMeta{Name: CmdOutput, MinArgs: 1, MaxArgs: 1, Supported: true},
-		CmdRun:        CommandMeta{Name: CmdRun, MinArgs: 1, MaxArgs: 2, Supported: true},
+		CmdRun:        CommandMeta{Name: CmdRun, MinArgs: 1, MaxArgs: 3, Supported: true},
 		CmdWorkDir:    CommandMeta{Name: CmdWorkDir, MinArgs: 1, MaxArgs: 1, Supported: true},
 	}
 )

--- a/script/run_cmd.go
+++ b/script/run_cmd.go
@@ -115,3 +115,10 @@ func (c *RunCommand) GetEffectiveCmdStr() (string, error) {
 	}
 	return cmdStr, nil
 }
+
+// GetEcho returns the echo param for command. When
+// set to {yes|true|on} the result of the command will be
+// redirected to the stdout|stderr
+func (c *RunCommand) GetEcho() string {
+	return ExpandEnv(c.cmd.args["echo"])
+}

--- a/script/run_cmd_test.go
+++ b/script/run_cmd_test.go
@@ -318,6 +318,28 @@ func TestCommandRUN(t *testing.T) {
 				return nil
 			},
 		},
+		{
+			name: "RUN with echo param",
+			source: func() string {
+				return `RUN shell:"/bin/bash -c" cmd:"echo 'HELLO WORLD'" echo:"true"`
+			},
+			script: func(s *Script) error {
+				if len(s.Actions) != 1 {
+					return fmt.Errorf("Script has unexpected actions, needs %d", len(s.Actions))
+				}
+				cmd := s.Actions[0].(*RunCommand)
+				if cmd.Args()["cmd"] != cmd.GetCmdString() {
+					return fmt.Errorf("RUN action with unexpected command string %s", cmd.GetCmdString())
+				}
+				if cmd.Args()["shell"] != cmd.GetCmdShell() {
+					return fmt.Errorf("RUN action with unexpected shell %s", cmd.GetCmdShell())
+				}
+				if cmd.Args()["echo"] != cmd.GetEcho() {
+					return fmt.Errorf("RUN action with unexpected echo param %s", cmd.GetCmdShell())
+				}
+				return nil
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This PR updates commands RUN and CAPTURE to add support param `echo` which will output command execution output to be sent to console as follows:

```
CAPTURE cmd:"echo 'HELLO WORLD'" echo:"true"
```

Related to issue #34 