### PR TITLE
Adds kube_config built-in

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.12
 
 require (
 	github.com/imdario/mergo v0.3.7 // indirect
+	github.com/onsi/ginkgo v1.10.1
+	github.com/onsi/gomega v1.7.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	github.com/vladimirvivien/echo v0.0.1-alpha.4

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,7 @@ github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7/go.mod h1:Fecb
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
@@ -117,9 +118,11 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.10.1 h1:q/mM8GF/n0shIN8SaAZ0V+jnLPzen6WIVZdiwrRlMlo=
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
@@ -232,11 +235,13 @@ google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZi
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/inf.v0 v0.9.0 h1:3zYtXIO92bvsdS3ggAdA8Gb4Azj0YU+TVY1uGYNFA8o=
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/starlark/kube_config.go
+++ b/starlark/kube_config.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package starlark
+
+import (
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+// addDefaultKubeConf initializes a Starlark Dict with default
+// KUBECONFIG configuration data
+func addDefaultKubeConf(thread *starlark.Thread) error {
+	args := []starlark.Tuple{
+		{starlark.String("path"), starlark.String(defaults.kubeconfig)},
+	}
+
+	_, err := kubeConfigFn(thread, nil, nil, args)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// kubeConfigFn is built-in starlark function that wraps the kwargs into a dictionary value.
+// The result is also added to the thread for other built-in to access.
+func kubeConfigFn(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var dictionary starlark.StringDict
+	if kwargs != nil {
+		dict, err := kwargsToStringDict(kwargs)
+		if err != nil {
+			return starlark.None, err
+		}
+		dictionary = dict
+	}
+
+	structVal := starlarkstruct.FromStringDict(starlarkstruct.Default, dictionary)
+
+	// save dict to be used as default
+	thread.SetLocal(identifiers.kubeCfg, structVal)
+
+	return structVal, nil
+}

--- a/starlark/kube_config_test.go
+++ b/starlark/kube_config_test.go
@@ -1,0 +1,94 @@
+package starlark
+
+import (
+	"strings"
+
+	"go.starlark.net/starlarkstruct"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("kube_config", func() {
+
+	var (
+		crashdScript string
+		executor     *Executor
+		err          error
+	)
+
+	execSetup := func() {
+		executor = New()
+		err = executor.Exec("test.kube.config", strings.NewReader(crashdScript))
+		Expect(err).To(BeNil())
+	}
+
+	Context("With kube_config set in the script", func() {
+
+		BeforeEach(func() {
+			crashdScript = `kube_config(path="/foo/bar/kube/config")`
+			execSetup()
+		})
+
+		It("sets the kube_config in the starlark thread", func() {
+			kubeConfigData := executor.thread.Local(identifiers.kubeCfg)
+			Expect(kubeConfigData).NotTo(BeNil())
+		})
+
+		It("sets the path to the kubeconfig file", func() {
+			kubeConfigData := executor.thread.Local(identifiers.kubeCfg)
+			Expect(kubeConfigData).To(BeAssignableToTypeOf(&starlarkstruct.Struct{}))
+
+			cfg, _ := kubeConfigData.(*starlarkstruct.Struct)
+			Expect(cfg.AttrNames()).To(HaveLen(1))
+
+			val, err := cfg.Attr("path")
+			Expect(err).To(BeNil())
+			Expect(trimQuotes(val.String())).To(Equal("/foo/bar/kube/config"))
+		})
+	})
+
+	Context("With kube_config returned as a value", func() {
+
+		BeforeEach(func() {
+			crashdScript = `cfg = kube_config(path="/foo/bar/kube/config")`
+			execSetup()
+		})
+
+		It("returns the kube config as a result", func() {
+			Expect(executor.result.Has("cfg")).NotTo(BeNil())
+		})
+
+		It("also sets the kube_config in the starlark thread", func() {
+			kubeConfigData := executor.thread.Local(identifiers.kubeCfg)
+			Expect(kubeConfigData).NotTo(BeNil())
+
+			cfg, _ := kubeConfigData.(*starlarkstruct.Struct)
+			Expect(cfg.AttrNames()).To(HaveLen(1))
+
+			val, err := cfg.Attr("path")
+			Expect(err).To(BeNil())
+			Expect(trimQuotes(val.String())).To(Equal("/foo/bar/kube/config"))
+		})
+	})
+
+	Context("With default kube_config setup", func() {
+
+		BeforeEach(func() {
+			crashdScript = `foo = "bar"`
+			execSetup()
+		})
+
+		It("sets the default kube_config in the starlark thread", func() {
+			kubeConfigData := executor.thread.Local(identifiers.kubeCfg)
+			Expect(kubeConfigData).NotTo(BeNil())
+
+			cfg, _ := kubeConfigData.(*starlarkstruct.Struct)
+			Expect(cfg.AttrNames()).To(HaveLen(1))
+
+			val, err := cfg.Attr("path")
+			Expect(err).To(BeNil())
+			Expect(trimQuotes(val.String())).To(ContainSubstring("/.kube/config"))
+		})
+	})
+})

--- a/starlark/starlark_exec.go
+++ b/starlark/starlark_exec.go
@@ -43,6 +43,7 @@ func newThreadLocal() *starlark.Thread {
 	thread := &starlark.Thread{Name: "crashd"}
 	addDefaultCrashdConf(thread)
 	addDefaultSSHConf(thread)
+	addDefaultKubeConf(thread)
 	return thread
 }
 
@@ -57,6 +58,7 @@ func newPredeclareds() starlark.StringDict {
 		identifiers.hostListProvider: starlark.NewBuiltin(identifiers.hostListProvider, hostListProvider),
 		identifiers.resources:        starlark.NewBuiltin(identifiers.resources, resourcesFunc),
 		identifiers.run:              starlark.NewBuiltin(identifiers.run, runFunc),
+		identifiers.kubeCfg:          starlark.NewBuiltin(identifiers.kubeCfg, kubeConfigFn),
 	}
 }
 

--- a/starlark/starlark_exec_test.go
+++ b/starlark/starlark_exec_test.go
@@ -23,6 +23,15 @@ func TestExec(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:   "kube_config only",
+			script: `kube_config()`,
+			eval: func(t *testing.T, script string) {
+				if err := New().Exec("test.file", strings.NewReader(script)); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/starlark/starlark_suite_test.go
+++ b/starlark/starlark_suite_test.go
@@ -1,0 +1,13 @@
+package starlark
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestStarlark(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Starlark Suite")
+}

--- a/starlark/support.go
+++ b/starlark/support.go
@@ -11,6 +11,7 @@ import (
 var (
 	identifiers = struct {
 		crashdCfg string
+		kubeCfg   string
 
 		sshCfg         string
 		port           string
@@ -26,6 +27,7 @@ var (
 		run              string
 	}{
 		crashdCfg: "crashd_config",
+		kubeCfg:   "kube_config",
 
 		sshCfg:         "ssh_config",
 		port:           "port",


### PR DESCRIPTION
Adds `kube_config` configuration function to allow setting the kubeconfig path for the crashd script. It overrides the global kubeconfig information present in the execution script context and can be passed to other directives explicitly. 

Examples:
```
kube_config(path="/tmp/foo/bar")
```
or 
```
cfg = kube_config(path="/tmp/foo/bar")
kube_capture(what="objects", namespaces=["default"], kube_config=cfg)
```