### PR TITLE
Starlark - Implement Command Function `capture()`

### DIFF
--- a/starlark/capture.go
+++ b/starlark/capture.go
@@ -1,0 +1,211 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package starlark
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+
+	"github.com/vmware-tanzu/crash-diagnostics/ssh"
+)
+
+// captureFunc is a built-in starlark function that runs a provided command and
+// captures the result of the command in a specified file stored in workdir.
+// If resources and workdir are not provided, captureFunc uses defaults from starlark thread generated
+// by previous calls to resources() and crashd_config().
+// Starlark format: capture(cmd="command" [,resources=resources][,workdir=path][,file_name=name][,desc=description])
+func captureFunc(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var cmdStr string
+	if args != nil && args.Len() == 1 {
+		cmd, ok := args.Index(0).(starlark.String)
+		if !ok {
+			return starlark.None, fmt.Errorf("%s: default argument must be a string", identifiers.capture)
+		}
+		cmdStr = string(cmd)
+	}
+
+	// grab named arguments
+	var dictionary starlark.StringDict
+	if kwargs != nil {
+		dict, err := kwargsToStringDict(kwargs)
+		if err != nil {
+			return starlark.None, err
+		}
+		dictionary = dict
+	}
+
+	if dictionary["cmd"] != nil {
+		if cmd, ok := dictionary["cmd"].(starlark.String); ok {
+			cmdStr = string(cmd)
+		}
+	}
+
+	if len(cmdStr) == 0 {
+		return starlark.None, fmt.Errorf("%s: missing command string", identifiers.capture)
+	}
+
+	var fileName string
+	if dictionary["file_name"] != nil {
+		if cmd, ok := dictionary["file_name"].(starlark.String); ok {
+			fileName = string(cmd)
+		}
+	}
+
+	var desc string
+	if dictionary["desc"] != nil {
+		if cmd, ok := dictionary["desc"].(starlark.String); ok {
+			desc = string(cmd)
+		}
+	}
+
+	// extract workdir
+	var workdir string
+	if dictionary["workdir"] != nil {
+		if dir, ok := dictionary["workdir"].(starlark.String); ok {
+			workdir = string(dir)
+		}
+	}
+	if len(workdir) == 0 {
+		if dir, err := getWorkdirFromThread(thread); err == nil {
+			workdir = dir
+		}
+	}
+	if len(workdir) == 0 {
+		workdir = defaults.workdir
+	}
+
+	// extract resources
+	var resources *starlark.List
+	if dictionary[identifiers.resources] != nil {
+		res, ok := dictionary[identifiers.resources].(*starlark.List)
+		if !ok {
+			return starlark.None, fmt.Errorf("%s: unexpected resources type", identifiers.capture)
+		}
+		resources = res
+	}
+	if resources == nil {
+		res := thread.Local(identifiers.resources)
+		if res == nil {
+			return starlark.None, fmt.Errorf("%s: default resources not found", identifiers.capture)
+		}
+		resList, ok := res.(*starlark.List)
+		if !ok {
+			return starlark.None, fmt.Errorf("%s: unexpected resources type", identifiers.capture)
+		}
+		resources = resList
+	}
+
+	results, err := execCapture(cmdStr, workdir, fileName, desc, resources)
+	if err != nil {
+		return starlark.None, err
+	}
+
+	// build list of struct as result
+	var resultList []starlark.Value
+	for _, result := range results {
+		if len(results) == 1 {
+			return result.toStarlarkStruct(), nil
+		}
+		resultList = append(resultList, result.toStarlarkStruct())
+	}
+
+	return starlark.NewList(resultList), nil
+}
+
+func execCapture(cmdStr, rootPath, fileName, desc string, resources *starlark.List) ([]runResult, error) {
+	if resources == nil {
+		return nil, fmt.Errorf("%s: missing resources", identifiers.capture)
+	}
+
+	logrus.Debugf("%s: executing command on %d resources", identifiers.capture, resources.Len())
+	var results []runResult
+	for i := 0; i < resources.Len(); i++ {
+		val := resources.Index(i)
+		res, ok := val.(*starlarkstruct.Struct)
+		if !ok {
+			return nil, fmt.Errorf("%s: unexpected resource type", identifiers.run)
+		}
+
+		val, err := res.Attr("kind")
+		if err != nil {
+			return nil, fmt.Errorf("%s: resource.kind: %s", identifiers.capture, err)
+		}
+		kind := val.(starlark.String)
+
+		val, err = res.Attr("transport")
+		if err != nil {
+			return nil, fmt.Errorf("%s: resource.transport: %s", identifiers.capture, err)
+		}
+		transport := val.(starlark.String)
+
+		val, err = res.Attr("host")
+		if err != nil {
+			return nil, fmt.Errorf("%s: resource.host: %s", identifiers.capture, err)
+		}
+		host := string(val.(starlark.String))
+		rootDir := filepath.Join(rootPath, sanitizeStr(host))
+
+		switch {
+		case string(kind) == identifiers.hostResource && string(transport) == "ssh":
+			result, err := execCaptureSSH(host, cmdStr, rootDir, fileName, desc, res)
+			if err != nil {
+				logrus.Error(err)
+				continue
+			}
+			results = append(results, result)
+		default:
+			logrus.Errorf("%s: unsupported or invalid resource kind: %s", identifiers.capture, kind)
+			continue
+		}
+	}
+
+	return results, nil
+}
+
+func execCaptureSSH(host, cmdStr, rootDir, fileName, desc string, res *starlarkstruct.Struct) (runResult, error) {
+	sshCfg := starlarkstruct.FromKeywords(starlarkstruct.Default, makeDefaultSSHConfig())
+	if val, err := res.Attr(identifiers.sshCfg); err == nil {
+		if cfg, ok := val.(*starlarkstruct.Struct); ok {
+			sshCfg = cfg
+		}
+	}
+
+	args, err := getSSHArgsFromCfg(sshCfg)
+	if err != nil {
+		return runResult{}, err
+	}
+	args.Host = host
+
+	// create dir for the host
+	if err := os.MkdirAll(rootDir, 0744); err != nil && !os.IsExist(err) {
+		return runResult{}, err
+	}
+
+	if len(fileName) == 0 {
+		fileName = fmt.Sprintf("%s.txt", sanitizeStr(cmdStr))
+	}
+	filePath := filepath.Join(rootDir, fileName)
+
+	logrus.Debugf("%s: capturing command on %s using ssh: [%s]", identifiers.capture, args.Host, cmdStr)
+
+	reader, err := ssh.RunRead(args, cmdStr)
+	if err != nil {
+		if err := captureOutput(strings.NewReader(err.Error()), filePath, fmt.Sprintf("%s: failed", cmdStr)); err != nil {
+			return runResult{}, err
+		}
+	}
+
+	if err := captureOutput(reader, filePath, desc); err != nil {
+		return runResult{}, err
+	}
+
+	return runResult{resource: args.Host, result: filePath, err: err}, nil
+
+}

--- a/starlark/crashd_config_test.go
+++ b/starlark/crashd_config_test.go
@@ -4,6 +4,7 @@
 package starlark
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -11,18 +12,14 @@ import (
 	"go.starlark.net/starlarkstruct"
 )
 
-func TestCrashdConfigNew(t *testing.T) {
+func testCrashdConfigNew(t *testing.T) {
 	e := New()
 	if e.thread == nil {
 		t.Error("thread is nil")
 	}
-	cfg := e.thread.Local(identifiers.crashdCfg)
-	if cfg == nil {
-		t.Error("crashd_config dict not found in thread")
-	}
 }
 
-func TestCrashdConfigFunc(t *testing.T) {
+func testCrashdConfigFunc(t *testing.T) {
 	tests := []struct {
 		name   string
 		script string
@@ -110,6 +107,23 @@ func TestCrashdConfigFunc(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			test.eval(t, test.script)
+		})
+	}
+}
+
+func TestCrashdCfgAll(t *testing.T) {
+	tests := []struct {
+		name string
+		test func(*testing.T)
+	}{
+		{name: "testCrashdConfigNew", test: testCrashdConfigNew},
+		{name: "testCrashdConfigFunc", test: testCrashdConfigFunc},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defer os.RemoveAll(defaults.workdir)
+			test.test(t)
 		})
 	}
 }

--- a/starlark/main_test.go
+++ b/starlark/main_test.go
@@ -38,3 +38,11 @@ func makeTestSSHHostResource(addr string, sshCfg *starlarkstruct.Struct) *starla
 		},
 	)
 }
+
+func newTestThreadLocal(t *testing.T) *starlark.Thread {
+	thread := &starlark.Thread{Name: "test-crashd"}
+	if err := setupLocalDefaults(thread); err != nil {
+		t.Fatalf("failed to setup new thread local: %s", err)
+	}
+	return thread
+}

--- a/starlark/resources_test.go
+++ b/starlark/resources_test.go
@@ -59,7 +59,7 @@ func TestResourcesFunc(t *testing.T) {
 				}
 			},
 			eval: func(t *testing.T, kwargs []starlark.Tuple) {
-				res, err := resourcesFunc(newThreadLocal(), nil, nil, kwargs)
+				res, err := resourcesFunc(newTestThreadLocal(t), nil, nil, kwargs)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -114,7 +114,7 @@ func TestResourcesFunc(t *testing.T) {
 			name: "provider only",
 			kwargs: func(t *testing.T) []starlark.Tuple {
 				provider, err := newHostListProvider(
-					newThreadLocal(),
+					newTestThreadLocal(t),
 					starlark.StringDict{"hosts": starlark.NewList(
 						[]starlark.Value{
 							starlark.String("local.host"),
@@ -130,7 +130,7 @@ func TestResourcesFunc(t *testing.T) {
 			},
 
 			eval: func(t *testing.T, kwargs []starlark.Tuple) {
-				res, err := resourcesFunc(newThreadLocal(), nil, nil, kwargs)
+				res, err := resourcesFunc(newTestThreadLocal(t), nil, nil, kwargs)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/starlark/run.go
+++ b/starlark/run.go
@@ -61,15 +61,14 @@ func runFunc(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, 
 	}
 
 	if dictionary["cmd"] != nil {
-		cmd, ok := dictionary["cmd"].(starlark.String)
-		if ok {
+		if cmd, ok := dictionary["cmd"].(starlark.String); ok {
 			cmdStr = string(cmd)
 		}
 	}
 
 	// extract resources
 	var resources *starlark.List
-	if dictionary["resources"] != nil {
+	if dictionary[identifiers.resources] != nil {
 		res, ok := dictionary[identifiers.resources].(*starlark.List)
 		if !ok {
 			return starlark.None, fmt.Errorf("%s: unexpected resources type", identifiers.run)

--- a/starlark/ssh_config_test.go
+++ b/starlark/ssh_config_test.go
@@ -15,10 +15,6 @@ func TestSSHConfigNew(t *testing.T) {
 	if e.thread == nil {
 		t.Error("thread is nil")
 	}
-	cfg := e.thread.Local(identifiers.sshCfg)
-	if cfg == nil {
-		t.Error("ssh_config dict not found in thread")
-	}
 }
 
 func TestSSHConfigFunc(t *testing.T) {


### PR DESCRIPTION
This PR is to implement command function `capture()` to support which allows the following script to work
 (given SSH is running on port 2424) and capture the result saved in a file at a pre-configured location:

```python
crashd_config(workdir="os.username/crashd")
ssh_config(username=os.username, port="2424")
resources(hosts=["127.0.0.1","localhost"])
capture("echo 'Hello World!'")
```

Or using additional args
```python
crashd_config(workdir="{}/crashd".format(os.home))
ssh_config(username=os.username, port="2424")
resources(hosts=["127.0.0.1","localhost"])
capture(cmd="echo 'Hello World!'", file_name="echo", desc="shows echo")
```