### PR TITLE
Implement kube_get starlark built-in

### DIFF
--- a/k8s/k8s_suite_test.go
+++ b/k8s/k8s_suite_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package k8s
 
 import (
@@ -11,3 +14,9 @@ func TestK8s(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "K8s Suite")
 }
+
+var searchResults []SearchResult
+
+var _ = BeforeSuite(func() {
+	searchResults = populateSearchResults()
+})

--- a/k8s/search_result.go
+++ b/k8s/search_result.go
@@ -1,11 +1,17 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package k8s
 
 import (
 	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// SearchResult is the object representation of the kubernetes objects
+// returned by querying the API server
 type SearchResult struct {
 	ListKind             string
 	ResourceName         string
@@ -16,7 +22,70 @@ type SearchResult struct {
 	Namespace            string
 }
 
-func (sr SearchResult) ToStarlarkValue() starlark.Value {
-	var val starlark.Value
-	return val
+// ToStarlarkValue converts the SearchResult object to a starlark dictionary
+func (sr SearchResult) ToStarlarkValue() *starlarkstruct.Struct {
+	var values []starlark.Value
+	listDict := starlark.StringDict{}
+
+	if sr.List != nil {
+		for _, item := range sr.List.Items {
+			values = append(values, convertToStruct(item))
+		}
+		listDict = starlark.StringDict{
+			"Object": convertToStarlarkPrimitive(sr.List.Object),
+			"Items":  starlark.NewList(values),
+		}
+	}
+	listStruct := starlarkstruct.FromStringDict(starlarkstruct.Default, listDict)
+
+	grValDict := starlark.StringDict{
+		"Group":    starlark.String(sr.GroupVersionResource.Group),
+		"Version":  starlark.String(sr.GroupVersionResource.Version),
+		"Resource": starlark.String(sr.GroupVersionResource.Resource),
+	}
+
+	dict := starlark.StringDict{
+		"ListKind":             starlark.String(sr.ListKind),
+		"ResourceName":         starlark.String(sr.ResourceName),
+		"ResourceKind":         starlark.String(sr.ResourceKind),
+		"Namespaced":           starlark.Bool(sr.Namespaced),
+		"Namespace":            starlark.String(sr.Namespace),
+		"GroupVersionResource": starlarkstruct.FromStringDict(starlarkstruct.Default, grValDict),
+		"List":                 listStruct,
+	}
+
+	return starlarkstruct.FromStringDict(starlarkstruct.Default, dict)
+}
+
+// convertToStruct returns a starlark struct constructed from the contents of the input.
+func convertToStruct(obj unstructured.Unstructured) starlark.Value {
+	return convertToStarlarkPrimitive(obj.Object)
+}
+
+func convertToStarlarkPrimitive(input interface{}) starlark.Value {
+	var value starlark.Value
+	switch input.(type) {
+	case string:
+		value = starlark.String(input.(string))
+	case int, int32, int64:
+		value = starlark.MakeInt64(input.(int64))
+	case bool:
+		value = starlark.Bool(input.(bool))
+	case []interface{}:
+		interfaceArr, _ := input.([]interface{})
+		var structs []starlark.Value
+		for _, i := range interfaceArr {
+			structs = append(structs, convertToStarlarkPrimitive(i))
+		}
+		value = starlark.NewList(structs)
+	case map[string]interface{}:
+		dict := starlark.StringDict{}
+		for k, v := range input.(map[string]interface{}) {
+			dict[k] = convertToStarlarkPrimitive(v)
+		}
+		value = starlarkstruct.FromStringDict(starlarkstruct.Default, dict)
+	default:
+		value = starlark.None
+	}
+	return value
 }

--- a/k8s/search_result_test.go
+++ b/k8s/search_result_test.go
@@ -1,35 +1,186 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package k8s
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
 )
+
+var populateSearchResults = func() []SearchResult {
+	content, err := ioutil.ReadFile("../testing/search_results.json")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(len(content)).NotTo(Equal(0))
+
+	var lists []unstructured.UnstructuredList
+	err = json.Unmarshal(content, &lists)
+	Expect(err).NotTo(HaveOccurred())
+
+	var results []SearchResult
+	for index, list := range lists {
+		Expect(list.Items).To(HaveLen(index + 1))
+		results = append(results, SearchResult{
+			List: list.DeepCopy(),
+		})
+	}
+	return results
+}
 
 var _ = Describe("SearchResult", func() {
 
 	Context("ToStarlarkValue", func() {
 
-		Context("ListKind", func() {
+		It("returns a dictionary of size equal to number of struct elements", func() {
 			sr := SearchResult{ListKind: "PodList"}
+			val := sr.ToStarlarkValue()
+			Expect(val).To(BeAssignableToTypeOf(&starlarkstruct.Struct{}))
+			Expect(val.AttrNames()).To(HaveLen(7))
+		})
 
-			It("creates value object with ListKind value", func() {
-				_ = sr.ToStarlarkValue()
+		sr := SearchResult{
+			ListKind:     "NodeList",
+			ResourceName: "nodes",
+			ResourceKind: "Node",
+			Namespace:    "",
+			Namespaced:   false,
+		}
+
+		DescribeTable("String types", func(typeDescription, stringVal string) {
+			structVal := sr.ToStarlarkValue()
+			val, err := structVal.Attr(typeDescription)
+			Expect(err).NotTo(HaveOccurred())
+
+			strVal, _ := val.(starlark.String)
+			Expect(strVal.GoString()).To(Equal(stringVal))
+		},
+			Entry("", "ListKind", "NodeList"),
+			Entry("", "ResourceName", "nodes"),
+			Entry("", "ResourceKind", "Node"),
+			Entry("", "Namespace", ""),
+		)
+
+		Context("For Namespaced", func() {
+			It(fmt.Sprintf("creates a dictionary with Namespaced value"), func() {
+				dict := sr.ToStarlarkValue()
+				val, err := dict.Attr("Namespaced")
+				Expect(err).NotTo(HaveOccurred())
+
+				boolVal, _ := val.(starlark.Bool)
+				Expect(boolVal.Truth()).To(Equal(starlark.False))
 			})
 		})
 
-		Context("For ResourceName", func() {
+		Context("For List", func() {
 
-		})
+			It("returns a starlark struct", func() {
+				sr = searchResults[0]
+				structVal := sr.ToStarlarkValue()
+				Expect(structVal).To(BeAssignableToTypeOf(&starlarkstruct.Struct{}))
 
-		Context("For ResourceKind", func() {
+				val, err := structVal.Attr("List")
+				Expect(err).NotTo(HaveOccurred())
 
-		})
+				_, ok := val.(*starlarkstruct.Struct)
+				Expect(ok).To(BeTrue())
+			})
 
-		Context("For Namespaced", func() {
+			It("contains a starlark struct with the Object key", func() {
+				sr = searchResults[0]
+				structVal := sr.ToStarlarkValue()
+				val, _ := structVal.Attr("List")
+				listVal, _ := val.(*starlarkstruct.Struct)
 
-		})
+				objVal, err := listVal.Attr("Object")
+				Expect(err).NotTo(HaveOccurred())
+				objStructVal, ok := objVal.(*starlarkstruct.Struct)
+				Expect(ok).To(BeTrue())
+				Expect(objStructVal).To(BeAssignableToTypeOf(&starlarkstruct.Struct{}))
+			})
 
-		Context("For Namespace", func() {
+			It("contains a starlark list with the Items key", func() {
+				sr = searchResults[0]
+				structVal := sr.ToStarlarkValue()
+				val, _ := structVal.Attr("List")
+				listVal, _ := val.(*starlarkstruct.Struct)
 
+				itemsVal, err := listVal.Attr("Items")
+				Expect(err).NotTo(HaveOccurred())
+				itemsListVal, ok := itemsVal.(*starlark.List)
+				Expect(ok).To(BeTrue())
+				Expect(itemsListVal).To(BeAssignableToTypeOf(&starlark.List{}))
+
+				Expect(itemsListVal.Len()).To(Equal(1))
+			})
+
+			Context("For each list entry", func() {
+
+				var listStructVal *starlarkstruct.Struct
+
+				BeforeEach(func() {
+					sr := searchResults[0]
+					structVal := sr.ToStarlarkValue()
+					val, _ := structVal.Attr("List")
+					listVal, _ := val.(*starlarkstruct.Struct)
+					itemsVal, _ := listVal.Attr("Items")
+					itemsListVal, _ := itemsVal.(*starlark.List)
+					listStructVal, _ = itemsListVal.Index(0).(*starlarkstruct.Struct)
+				})
+
+				It("returns a starlark string for a string value", func() {
+					kindAttrVal, err := listStructVal.Attr("kind")
+					Expect(err).NotTo(HaveOccurred())
+					if kind, ok := kindAttrVal.(starlark.String); !ok {
+						Expect(kind.GoString()).To(Equal("Service"))
+					} else {
+						Expect(ok).To(BeTrue())
+					}
+
+					apiVersionVal, err := listStructVal.Attr("apiVersion")
+					Expect(err).NotTo(HaveOccurred())
+					if version, ok := apiVersionVal.(starlark.String); ok {
+						Expect(version.GoString()).To(Equal("v1"))
+					} else {
+						Expect(ok).To(BeTrue())
+					}
+				})
+
+				It("returns a starlark struct for a map value", func() {
+					metadataAttrVal, err := listStructVal.Attr("metadata")
+					Expect(err).NotTo(HaveOccurred())
+					metadata, ok := metadataAttrVal.(*starlarkstruct.Struct)
+					Expect(ok).To(BeTrue())
+
+					labelVal, err := metadata.Attr("labels")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(labelVal).To(BeAssignableToTypeOf(&starlarkstruct.Struct{}))
+				})
+
+				It("returns a starlark list for an array value", func() {
+					specAttrVal, err := listStructVal.Attr("spec")
+					Expect(err).NotTo(HaveOccurred())
+					spec, ok := specAttrVal.(*starlarkstruct.Struct)
+					Expect(ok).To(BeTrue())
+
+					portsVal, err := spec.Attr("ports")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(portsVal).To(BeAssignableToTypeOf(&starlark.List{}))
+
+					ports, ok := portsVal.(*starlark.List)
+					Expect(ok).To(BeTrue())
+					Expect(ports.Len()).To(Equal(3))
+					Expect(ports.Index(0)).To(BeAssignableToTypeOf(&starlarkstruct.Struct{}))
+				})
+			})
 		})
 	})
 })

--- a/starlark/kube_config.go
+++ b/starlark/kube_config.go
@@ -8,6 +8,26 @@ import (
 	"go.starlark.net/starlarkstruct"
 )
 
+// kubeConfigFn is built-in starlark function that wraps the kwargs into a dictionary value.
+// The result is also added to the thread for other built-in to access.
+func kubeConfigFn(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var dictionary starlark.StringDict
+
+	if kwargs != nil {
+		dict, err := kwargsToStringDict(kwargs)
+		if err != nil {
+			return starlark.None, err
+		}
+		dictionary = dict
+	}
+	structVal := starlarkstruct.FromStringDict(starlarkstruct.Default, dictionary)
+
+	// save dict to be used as default
+	thread.SetLocal(identifiers.kubeCfg, structVal)
+
+	return structVal, nil
+}
+
 // addDefaultKubeConf initializes a Starlark Dict with default
 // KUBECONFIG configuration data
 func addDefaultKubeConf(thread *starlark.Thread) error {
@@ -21,24 +41,4 @@ func addDefaultKubeConf(thread *starlark.Thread) error {
 	}
 
 	return nil
-}
-
-// kubeConfigFn is built-in starlark function that wraps the kwargs into a dictionary value.
-// The result is also added to the thread for other built-in to access.
-func kubeConfigFn(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var dictionary starlark.StringDict
-	if kwargs != nil {
-		dict, err := kwargsToStringDict(kwargs)
-		if err != nil {
-			return starlark.None, err
-		}
-		dictionary = dict
-	}
-
-	structVal := starlarkstruct.FromStringDict(starlarkstruct.Default, dictionary)
-
-	// save dict to be used as default
-	thread.SetLocal(identifiers.kubeCfg, structVal)
-
-	return structVal, nil
 }

--- a/starlark/kube_config_test.go
+++ b/starlark/kube_config_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package starlark
 
 import (

--- a/starlark/kube_get.go
+++ b/starlark/kube_get.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package starlark
+
+import (
+	"github.com/pkg/errors"
+	"github.com/vmware-tanzu/crash-diagnostics/k8s"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+// KubeGetFn is a starlark built-in for the fetching kubernetes objects
+func KubeGetFn(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var objects *starlark.List
+
+	structVal, err := kwargsToStruct(kwargs)
+	if err != nil {
+		return starlark.None, err
+	}
+
+	kubeconfig, err := getKubeConfigPath(thread, structVal)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to kubeconfig")
+	}
+	client, err := k8s.New(kubeconfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not initialize search client")
+	}
+
+	searchParams := k8s.NewSearchParams(structVal)
+	searchResults, err := client.Search(searchParams.Groups(), searchParams.Kinds(), searchParams.Namespaces(), searchParams.Versions(), searchParams.Names(), searchParams.Labels(), searchParams.Containers())
+	if err == nil {
+		objects = starlark.NewList([]starlark.Value{})
+		for _, searchResult := range searchResults {
+			srValue := searchResult.ToStarlarkValue()
+			err = objects.Append(srValue)
+			if err != nil {
+				err = errors.Wrap(err, "could not collect kube_get() results")
+				break
+			}
+		}
+	}
+
+	return starlarkstruct.FromStringDict(
+		starlarkstruct.Default,
+		starlark.StringDict{
+			"objs": objects,
+			"error": func() starlark.String {
+				if err != nil {
+					return starlark.String(err.Error())
+				}
+				return ""
+			}(),
+		}), nil
+}

--- a/starlark/kube_get_test.go
+++ b/starlark/kube_get_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package starlark
+
+import (
+	"fmt"
+	"strings"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("kube_get", func() {
+
+	var (
+		executor *Executor
+		err      error
+	)
+
+	execSetup := func(crashdScript string) {
+		executor = New()
+		err = executor.Exec("test.kube.get", strings.NewReader(crashdScript))
+	}
+
+	It("returns a list of k8s services as starlark objects", func() {
+		crashdScript := fmt.Sprintf(`
+kube_config(path="%s")
+kube_get_data = kube_get(groups="core", kinds="services", namespaces=["default", "kube-system"])
+		`, k8sconfig)
+		execSetup(crashdScript)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(executor.result.Has("kube_get_data")).NotTo(BeNil())
+
+		data := executor.result["kube_get_data"]
+		Expect(data).NotTo(BeNil())
+
+		dataStruct, ok := data.(*starlarkstruct.Struct)
+		Expect(ok).To(BeTrue())
+
+		objects, err := dataStruct.Attr("objs")
+		Expect(err).NotTo(HaveOccurred())
+
+		getDataList, _ := objects.(*starlark.List)
+		Expect(getDataList.Len()).To(Equal(2))
+	})
+
+	It("returns a list of k8s nodes as starlark objects", func() {
+		crashdScript := fmt.Sprintf(`
+kube_config(path="%s")
+kube_get_data = kube_get(groups="core", kinds="nodes")
+			`, k8sconfig)
+		execSetup(crashdScript)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(executor.result.Has("kube_get_data")).NotTo(BeNil())
+
+		data := executor.result["kube_get_data"]
+		Expect(data).NotTo(BeNil())
+
+		dataStruct, ok := data.(*starlarkstruct.Struct)
+		Expect(ok).To(BeTrue())
+
+		objects, err := dataStruct.Attr("objs")
+		Expect(err).NotTo(HaveOccurred())
+
+		getDataList, _ := objects.(*starlark.List)
+		Expect(getDataList.Len()).To(Equal(1))
+	})
+
+	It("returns a list of etcd containers as starlark objects", func() {
+		crashdScript := fmt.Sprintf(`
+kube_config(path="%s")
+kube_get_data = kube_get(namespaces="kube-system", containers=["etcd"])
+			`, k8sconfig)
+		execSetup(crashdScript)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(executor.result.Has("kube_get_data")).NotTo(BeNil())
+
+		data := executor.result["kube_get_data"]
+		Expect(data).NotTo(BeNil())
+
+		dataStruct, ok := data.(*starlarkstruct.Struct)
+		Expect(ok).To(BeTrue())
+
+		objects, err := dataStruct.Attr("objs")
+		Expect(err).NotTo(HaveOccurred())
+
+		getDataList, _ := objects.(*starlark.List)
+		Expect(getDataList.Len()).To(BeNumerically(">=", 1))
+	})
+
+	DescribeTable("Incorrect kubeconfig", func(crashdScript string) {
+		execSetup(crashdScript)
+		Expect(err).To(HaveOccurred())
+	},
+		Entry("in global thread", fmt.Sprintf(`
+kube_config(path="%s")
+kube_get(namespaces="kube-system", containers=["etcd"])`, "/foo/bar")),
+		Entry("in function call", fmt.Sprintf(`
+cfg = kube_config(path="%s")
+kube_get(namespaces="kube-system", containers=["etcd"], kube_config=cfg)`, "/foo/bar")),
+	)
+})

--- a/starlark/starlark_exec.go
+++ b/starlark/starlark_exec.go
@@ -69,15 +69,16 @@ func setupLocalDefaults(thread *starlark.Thread) error {
 // runing script.
 func newPredeclareds() starlark.StringDict {
 	return starlark.StringDict{
-		"os":                             setupOSStruct(),
-		identifiers.crashdCfg:            starlark.NewBuiltin(identifiers.crashdCfg, crashdConfigFn),
-		identifiers.sshCfg:               starlark.NewBuiltin(identifiers.sshCfg, sshConfigFn),
-		identifiers.hostListProvider:     starlark.NewBuiltin(identifiers.hostListProvider, hostListProvider),
-		identifiers.resources:            starlark.NewBuiltin(identifiers.resources, resourcesFunc),
-		identifiers.run:                  starlark.NewBuiltin(identifiers.run, runFunc),
-		identifiers.capture:              starlark.NewBuiltin(identifiers.capture, captureFunc),
-		identifiers.kubeCfg:              starlark.NewBuiltin(identifiers.kubeCfg, kubeConfigFn),
-		identifiers.kubeCaptureDirective: starlark.NewBuiltin(identifiers.kubeGetDirective, KubeCaptureFn),
+		"os":                         setupOSStruct(),
+		identifiers.crashdCfg:        starlark.NewBuiltin(identifiers.crashdCfg, crashdConfigFn),
+		identifiers.sshCfg:           starlark.NewBuiltin(identifiers.sshCfg, sshConfigFn),
+		identifiers.hostListProvider: starlark.NewBuiltin(identifiers.hostListProvider, hostListProvider),
+		identifiers.resources:        starlark.NewBuiltin(identifiers.resources, resourcesFunc),
+		identifiers.run:              starlark.NewBuiltin(identifiers.run, runFunc),
+		identifiers.capture:          starlark.NewBuiltin(identifiers.capture, captureFunc),
+		identifiers.kubeCfg:          starlark.NewBuiltin(identifiers.kubeCfg, kubeConfigFn),
+		identifiers.kubeCapture:      starlark.NewBuiltin(identifiers.kubeGet, KubeCaptureFn),
+		identifiers.kubeGet:          starlark.NewBuiltin(identifiers.kubeGet, KubeGetFn),
 	}
 }
 

--- a/starlark/starlark_suite_test.go
+++ b/starlark/starlark_suite_test.go
@@ -1,13 +1,51 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package starlark
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	testcrashd "github.com/vmware-tanzu/crash-diagnostics/testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+)
+
+var (
+	kind      *testcrashd.KindCluster
+	waitTime  = time.Second * 11
+	k8sconfig string
 )
 
 func TestStarlark(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Starlark Suite")
 }
+
+var _ = BeforeSuite(func() {
+	clusterName := "crashd-test-cluster"
+	tmpFile, err := ioutil.TempFile(os.TempDir(), clusterName)
+	Expect(err).NotTo(HaveOccurred())
+	k8sconfig = tmpFile.Name()
+
+	// create kind cluster
+	kind = testcrashd.NewKindCluster("../testing/kind-cluster-docker.yaml", clusterName)
+	err = kind.Create()
+	Expect(err).NotTo(HaveOccurred())
+
+	err = kind.MakeKubeConfigFile(k8sconfig)
+	Expect(err).NotTo(HaveOccurred())
+
+	logrus.Infof("Sleeping %v ... waiting for pods", waitTime)
+	time.Sleep(waitTime)
+})
+
+var _ = AfterSuite(func() {
+	kind.Destroy()
+	os.RemoveAll(k8sconfig)
+})

--- a/starlark/support.go
+++ b/starlark/support.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package starlark
 
 import (
@@ -35,14 +38,13 @@ var (
 		run              string
 		capture          string
 
-		// Directives
-		kubeCaptureDirective string
-		kubeGetDirective     string
+		kubeCapture string
+		kubeGet     string
 	}{
 		crashdCfg: "crashd_config",
 		kubeCfg:   "kube_config",
+		sshCfg:    "ssh_config",
 
-		sshCfg:         "ssh_config",
 		port:           "port",
 		username:       "username",
 		privateKeyPath: "private_key_path",
@@ -56,8 +58,8 @@ var (
 		run:              "run",
 		capture:          "capture",
 
-		kubeGetDirective:     "kube_get",
-		kubeCaptureDirective: "kube_capture",
+		kubeCapture: "kube_capture",
+		kubeGet:     "kube_get",
 	}
 
 	defaults = struct {

--- a/testing/search_results.json
+++ b/testing/search_results.json
@@ -1,0 +1,530 @@
+[
+  {
+  "apiVersion": "v1",
+  "items": [
+     {
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {
+        "annotations": {
+          "prometheus.io/port": "9153",
+          "prometheus.io/scrape": "true"
+        },
+        "creationTimestamp": "2020-06-26T22:05:49Z",
+        "labels": {
+          "k8s-app": "kube-dns",
+          "kubernetes.io/cluster-service": "true",
+          "kubernetes.io/name": "KubeDNS"
+        },
+        "name": "kube-dns",
+        "namespace": "kube-system",
+        "resourceVersion": "182",
+        "selfLink": "/api/v1/namespaces/kube-system/services/kube-dns",
+        "uid": "925e05dc-fc0e-4871-92bf-fe15bddc5645"
+      },
+      "spec": {
+        "clusterIP": "10.96.0.10",
+        "ports": [
+          {
+            "name": "dns",
+            "port": 53,
+            "protocol": "UDP",
+            "targetPort": 53
+          },
+          {
+            "name": "dns-tcp",
+            "port": 53,
+            "protocol": "TCP",
+            "targetPort": 53
+          },
+          {
+            "name": "metrics",
+            "port": 9153,
+            "protocol": "TCP",
+            "targetPort": 9153
+          }
+        ],
+        "selector": {
+          "k8s-app": "kube-dns"
+        },
+        "sessionAffinity": "None",
+        "type": "ClusterIP"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ],
+  "kind": "ServiceList",
+  "metadata": {
+    "resourceVersion": "597",
+    "selfLink": "/api/v1/namespaces/kube-system/services"
+  }
+  },
+  {
+    "apiVersion": "v1",
+    "items": [
+      {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "creationTimestamp": "2020-06-26T22:06:06Z",
+          "generateName": "coredns-6955765f44-",
+          "labels": {
+            "k8s-app": "kube-dns",
+            "pod-template-hash": "6955765f44"
+          },
+          "name": "coredns-6955765f44-8kpv7",
+          "namespace": "kube-system",
+          "ownerReferences": [
+            {
+              "apiVersion": "apps/v1",
+              "blockOwnerDeletion": true,
+              "controller": true,
+              "kind": "ReplicaSet",
+              "name": "coredns-6955765f44",
+              "uid": "07355621-050e-4531-94b7-dc57adc344d2"
+            }
+          ],
+          "resourceVersion": "530",
+          "selfLink": "/api/v1/namespaces/kube-system/pods/coredns-6955765f44-8kpv7",
+          "uid": "315e3700-27a0-44d3-9906-0f1ae55505ca"
+        },
+        "spec": {
+          "containers": [
+            {
+              "args": [
+                "-conf",
+                "/etc/coredns/Corefile"
+              ],
+              "image": "k8s.gcr.io/coredns:1.6.5",
+              "imagePullPolicy": "IfNotPresent",
+              "livenessProbe": {
+                "failureThreshold": 5,
+                "httpGet": {
+                  "path": "/health",
+                  "port": 8080,
+                  "scheme": "HTTP"
+                },
+                "initialDelaySeconds": 60,
+                "periodSeconds": 10,
+                "successThreshold": 1,
+                "timeoutSeconds": 5
+              },
+              "name": "coredns",
+              "ports": [
+                {
+                  "containerPort": 53,
+                  "name": "dns",
+                  "protocol": "UDP"
+                },
+                {
+                  "containerPort": 53,
+                  "name": "dns-tcp",
+                  "protocol": "TCP"
+                },
+                {
+                  "containerPort": 9153,
+                  "name": "metrics",
+                  "protocol": "TCP"
+                }
+              ],
+              "readinessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/ready",
+                  "port": 8181,
+                  "scheme": "HTTP"
+                },
+                "periodSeconds": 10,
+                "successThreshold": 1,
+                "timeoutSeconds": 1
+              },
+              "resources": {
+                "limits": {
+                  "memory": "170Mi"
+                },
+                "requests": {
+                  "cpu": "100m",
+                  "memory": "70Mi"
+                }
+              },
+              "securityContext": {
+                "allowPrivilegeEscalation": false,
+                "capabilities": {
+                  "add": [
+                    "NET_BIND_SERVICE"
+                  ],
+                  "drop": [
+                    "all"
+                  ]
+                },
+                "readOnlyRootFilesystem": true
+              },
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File",
+              "volumeMounts": [
+                {
+                  "mountPath": "/etc/coredns",
+                  "name": "config-volume",
+                  "readOnly": true
+                },
+                {
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "coredns-token-stwjp",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "dnsPolicy": "Default",
+          "enableServiceLinks": true,
+          "nodeName": "crashd-test-kube-control-plane",
+          "nodeSelector": {
+            "beta.kubernetes.io/os": "linux"
+          },
+          "priority": 2000000000,
+          "priorityClassName": "system-cluster-critical",
+          "restartPolicy": "Always",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "serviceAccount": "coredns",
+          "serviceAccountName": "coredns",
+          "terminationGracePeriodSeconds": 30,
+          "tolerations": [
+            {
+              "key": "CriticalAddonsOnly",
+              "operator": "Exists"
+            },
+            {
+              "effect": "NoSchedule",
+              "key": "node-role.kubernetes.io/master"
+            },
+            {
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/not-ready",
+              "operator": "Exists",
+              "tolerationSeconds": 300
+            },
+            {
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/unreachable",
+              "operator": "Exists",
+              "tolerationSeconds": 300
+            }
+          ],
+          "volumes": [
+            {
+              "configMap": {
+                "defaultMode": 420,
+                "items": [
+                  {
+                    "key": "Corefile",
+                    "path": "Corefile"
+                  }
+                ],
+                "name": "coredns"
+              },
+              "name": "config-volume"
+            },
+            {
+              "name": "coredns-token-stwjp",
+              "secret": {
+                "defaultMode": 420,
+                "secretName": "coredns-token-stwjp"
+              }
+            }
+          ]
+        },
+        "status": {
+          "conditions": [
+            {
+              "lastProbeTime": null,
+              "lastTransitionTime": "2020-06-26T22:06:21Z",
+              "status": "True",
+              "type": "Initialized"
+            },
+            {
+              "lastProbeTime": null,
+              "lastTransitionTime": "2020-06-26T22:06:31Z",
+              "status": "True",
+              "type": "Ready"
+            },
+            {
+              "lastProbeTime": null,
+              "lastTransitionTime": "2020-06-26T22:06:31Z",
+              "status": "True",
+              "type": "ContainersReady"
+            },
+            {
+              "lastProbeTime": null,
+              "lastTransitionTime": "2020-06-26T22:06:21Z",
+              "status": "True",
+              "type": "PodScheduled"
+            }
+          ],
+          "containerStatuses": [
+            {
+              "containerID": "containerd://bbf4579465753090a8a4c4302a534be8113d34e5a6222be7d8229765b1f97de9",
+              "image": "k8s.gcr.io/coredns:1.6.5",
+              "imageID": "sha256:70f311871ae12c14bd0e02028f249f933f925e4370744e4e35f706da773a8f61",
+              "lastState": {},
+              "name": "coredns",
+              "ready": true,
+              "restartCount": 0,
+              "started": true,
+              "state": {
+                "running": {
+                  "startedAt": "2020-06-26T22:06:22Z"
+                }
+              }
+            }
+          ],
+          "hostIP": "172.17.0.3",
+          "phase": "Running",
+          "podIP": "10.244.0.2",
+          "podIPs": [
+            {
+              "ip": "10.244.0.2"
+            }
+          ],
+          "qosClass": "Burstable",
+          "startTime": "2020-06-26T22:06:21Z"
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "creationTimestamp": "2020-06-26T22:06:06Z",
+          "generateName": "coredns-6955765f44-",
+          "labels": {
+            "k8s-app": "kube-dns",
+            "pod-template-hash": "6955765f44"
+          },
+          "name": "coredns-6955765f44-jv8dd",
+          "namespace": "kube-system",
+          "ownerReferences": [
+            {
+              "apiVersion": "apps/v1",
+              "blockOwnerDeletion": true,
+              "controller": true,
+              "kind": "ReplicaSet",
+              "name": "coredns-6955765f44",
+              "uid": "07355621-050e-4531-94b7-dc57adc344d2"
+            }
+          ],
+          "resourceVersion": "498",
+          "selfLink": "/api/v1/namespaces/kube-system/pods/coredns-6955765f44-jv8dd",
+          "uid": "63853acf-a51b-4094-8e03-4e542e08ed91"
+        },
+        "spec": {
+          "containers": [
+            {
+              "args": [
+                "-conf",
+                "/etc/coredns/Corefile"
+              ],
+              "image": "k8s.gcr.io/coredns:1.6.5",
+              "imagePullPolicy": "IfNotPresent",
+              "livenessProbe": {
+                "failureThreshold": 5,
+                "httpGet": {
+                  "path": "/health",
+                  "port": 8080,
+                  "scheme": "HTTP"
+                },
+                "initialDelaySeconds": 60,
+                "periodSeconds": 10,
+                "successThreshold": 1,
+                "timeoutSeconds": 5
+              },
+              "name": "coredns",
+              "ports": [
+                {
+                  "containerPort": 53,
+                  "name": "dns",
+                  "protocol": "UDP"
+                },
+                {
+                  "containerPort": 53,
+                  "name": "dns-tcp",
+                  "protocol": "TCP"
+                },
+                {
+                  "containerPort": 9153,
+                  "name": "metrics",
+                  "protocol": "TCP"
+                }
+              ],
+              "readinessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/ready",
+                  "port": 8181,
+                  "scheme": "HTTP"
+                },
+                "periodSeconds": 10,
+                "successThreshold": 1,
+                "timeoutSeconds": 1
+              },
+              "resources": {
+                "limits": {
+                  "memory": "170Mi"
+                },
+                "requests": {
+                  "cpu": "100m",
+                  "memory": "70Mi"
+                }
+              },
+              "securityContext": {
+                "allowPrivilegeEscalation": false,
+                "capabilities": {
+                  "add": [
+                    "NET_BIND_SERVICE"
+                  ],
+                  "drop": [
+                    "all"
+                  ]
+                },
+                "readOnlyRootFilesystem": true
+              },
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File",
+              "volumeMounts": [
+                {
+                  "mountPath": "/etc/coredns",
+                  "name": "config-volume",
+                  "readOnly": true
+                },
+                {
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "coredns-token-stwjp",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "dnsPolicy": "Default",
+          "enableServiceLinks": true,
+          "nodeName": "crashd-test-kube-control-plane",
+          "nodeSelector": {
+            "beta.kubernetes.io/os": "linux"
+          },
+          "priority": 2000000000,
+          "priorityClassName": "system-cluster-critical",
+          "restartPolicy": "Always",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "serviceAccount": "coredns",
+          "serviceAccountName": "coredns",
+          "terminationGracePeriodSeconds": 30,
+          "tolerations": [
+            {
+              "key": "CriticalAddonsOnly",
+              "operator": "Exists"
+            },
+            {
+              "effect": "NoSchedule",
+              "key": "node-role.kubernetes.io/master"
+            },
+            {
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/not-ready",
+              "operator": "Exists",
+              "tolerationSeconds": 300
+            },
+            {
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/unreachable",
+              "operator": "Exists",
+              "tolerationSeconds": 300
+            }
+          ],
+          "volumes": [
+            {
+              "configMap": {
+                "defaultMode": 420,
+                "items": [
+                  {
+                    "key": "Corefile",
+                    "path": "Corefile"
+                  }
+                ],
+                "name": "coredns"
+              },
+              "name": "config-volume"
+            },
+            {
+              "name": "coredns-token-stwjp",
+              "secret": {
+                "defaultMode": 420,
+                "secretName": "coredns-token-stwjp"
+              }
+            }
+          ]
+        },
+        "status": {
+          "conditions": [
+            {
+              "lastProbeTime": null,
+              "lastTransitionTime": "2020-06-26T22:06:21Z",
+              "status": "True",
+              "type": "Initialized"
+            },
+            {
+              "lastProbeTime": null,
+              "lastTransitionTime": "2020-06-26T22:06:22Z",
+              "status": "True",
+              "type": "Ready"
+            },
+            {
+              "lastProbeTime": null,
+              "lastTransitionTime": "2020-06-26T22:06:22Z",
+              "status": "True",
+              "type": "ContainersReady"
+            },
+            {
+              "lastProbeTime": null,
+              "lastTransitionTime": "2020-06-26T22:06:21Z",
+              "status": "True",
+              "type": "PodScheduled"
+            }
+          ],
+          "containerStatuses": [
+            {
+              "containerID": "containerd://5961bf371b76460b96ad197b5675dfd10e2b3186d38728677bad6f7c37782114",
+              "image": "k8s.gcr.io/coredns:1.6.5",
+              "imageID": "sha256:70f311871ae12c14bd0e02028f249f933f925e4370744e4e35f706da773a8f61",
+              "lastState": {},
+              "name": "coredns",
+              "ready": true,
+              "restartCount": 0,
+              "started": true,
+              "state": {
+                "running": {
+                  "startedAt": "2020-06-26T22:06:22Z"
+                }
+              }
+            }
+          ],
+          "hostIP": "172.17.0.3",
+          "phase": "Running",
+          "podIP": "10.244.0.3",
+          "podIPs": [
+            {
+              "ip": "10.244.0.3"
+            }
+          ],
+          "qosClass": "Burstable",
+          "startTime": "2020-06-26T22:06:21Z"
+        }
+      }
+    ],
+    "kind": "PodList",
+    "metadata": {
+      "resourceVersion": "578",
+      "selfLink": "/api/v1/namespaces/kube-system/pods"
+    }
+  }
+]


### PR DESCRIPTION
This patch includes the kube_get() built-in which can query and present the k8s objects as starlark values which can be usd to use in the starlark based crashd configuration file.
Example:
```
kube_cfg = kube_config(path="/tmp/kube_config")
kube_get(groups="core", namespaces=["default", "kube-system"], kube_config=kube_cfg)
```
or 
```
kube_get(groups="core", kinds=''deployments' namespaces=["default", "kube-system"])
```

### TODO:
- [x] Fixes bug about accepting `kube_config`
- [x] Convert the ListItem from SearchResult into a Starlark value.