### PR TITLE
Ability to pass script level arguments

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -13,12 +13,14 @@ import (
 
 type runFlags struct {
 	file string
+	args map[string]string
 }
 
 // newRunCommand creates a command to run the Diagnostics script a file
 func newRunCommand() *cobra.Command {
 	flags := &runFlags{
 		file: "Diagnostics.file",
+		args: nil,
 	}
 
 	cmd := &cobra.Command{
@@ -31,6 +33,7 @@ func newRunCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flags.file, "file", flags.file, "the path to the diagnostics script file to run")
+	cmd.Flags().StringToStringVar(&flags.args, "args", flags.args, "key-value pair of script arguments which can be used in the diagnostics file")
 	return cmd
 }
 
@@ -40,6 +43,9 @@ func run(flag *runFlags, _ []string) error {
 	}
 
 	executor := starlark.New()
+	if flag.args != nil {
+		executor.WithArgs(flag.args)
+	}
 	if err := executor.Exec(flag.file, nil); err != nil {
 		return err
 	}

--- a/starlark/starlark_exec.go
+++ b/starlark/starlark_exec.go
@@ -26,6 +26,14 @@ func New() *Executor {
 	}
 }
 
+func (e *Executor) WithArgs(args map[string]string) {
+	dict := starlark.StringDict{}
+	for k, v := range args {
+		dict[k] = starlark.String(v)
+	}
+	e.predecs[identifiers.args] = starlarkstruct.FromStringDict(starlarkstruct.Default, dict)
+}
+
 func (e *Executor) Exec(name string, source io.Reader) error {
 	if err := setupLocalDefaults(e.thread); err != nil {
 		return fmt.Errorf("crashd failed: %s", err)

--- a/starlark/starlark_exec_test.go
+++ b/starlark/starlark_exec_test.go
@@ -6,6 +6,8 @@ package starlark
 import (
 	"strings"
 	"testing"
+
+	"go.starlark.net/starlarkstruct"
 )
 
 func TestExec(t *testing.T) {
@@ -38,6 +40,73 @@ func TestExec(t *testing.T) {
 			eval: func(t *testing.T, script string) {
 				if err := New().Exec("test.file", strings.NewReader(script)); err != nil {
 					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name:   "args only",
+			script: `cfg = ssh_config(username=args.username)`,
+			eval: func(t *testing.T, script string) {
+				e := New()
+				e.WithArgs(map[string]string{
+					"username": "foo",
+				})
+				if err := e.Exec("test.file", strings.NewReader(script)); err != nil {
+					t.Fatal(err)
+				}
+				data := e.result["cfg"]
+				if data == nil {
+					t.Fatal("ssh_config function not returning value")
+				}
+				cfg, ok := data.(*starlarkstruct.Struct)
+				if !ok {
+					t.Fatalf("unexpected type for thread local key ssh_config: %T", data)
+				}
+
+				val, err := cfg.Attr("username")
+				if err != nil {
+					t.Fatal(err)
+				}
+				if trimQuotes(val.String()) != "foo" {
+					t.Fatalf("unexpected value for key 'username': %s", val.String())
+				}
+			},
+		},
+		{
+			name:   "multiple args",
+			script: `cfg = ssh_config(username=args.username, port=args.ssh_port)`,
+			eval: func(t *testing.T, script string) {
+				e := New()
+				e.WithArgs(map[string]string{
+					"username": "bar",
+					"ssh_port": "1234",
+				})
+				if err := e.Exec("test.file", strings.NewReader(script)); err != nil {
+					t.Fatal(err)
+				}
+				data := e.result["cfg"]
+				if data == nil {
+					t.Fatal("ssh_config function not returning value")
+				}
+				cfg, ok := data.(*starlarkstruct.Struct)
+				if !ok {
+					t.Fatalf("unexpected type for thread local key ssh_config: %T", data)
+				}
+
+				val, err := cfg.Attr("username")
+				if err != nil {
+					t.Fatal(err)
+				}
+				if trimQuotes(val.String()) != "bar" {
+					t.Fatalf("unexpected value for key 'username': %s", val.String())
+				}
+
+				portVal, err := cfg.Attr("port")
+				if err != nil {
+					t.Fatal(err)
+				}
+				if trimQuotes(portVal.String()) != "1234" {
+					t.Fatalf("unexpected value for key 'port': %s", val.String())
 				}
 			},
 		},

--- a/starlark/support.go
+++ b/starlark/support.go
@@ -42,6 +42,8 @@ var (
 		kubeCapture       string
 		kubeGet           string
 		kubeNodesProvider string
+
+		args string
 	}{
 		crashdCfg: "crashd_config",
 		kubeCfg:   "kube_config",
@@ -66,6 +68,8 @@ var (
 		kubeCapture:       "kube_capture",
 		kubeGet:           "kube_get",
 		kubeNodesProvider: "kube_nodes_provider",
+
+		args: "args",
 	}
 
 	defaults = struct {


### PR DESCRIPTION
Allow the user to pass an arbitrary map of key value pairs which are available in the diagnostics script as a dictionary with the name `args`. To facilitate this, a new `--args` flag has been added to the `run` command of the crash-diagnostics program.

Example:
```python
cfg = ssh_config(username=args.username, port=args.ssh_port)
resources(provider=host_list_provider(hosts=["foo.host.1","foo.host.2"], ssh_config=cfg))
```
And the crash-diagnostics binary should be run with:
```bash
$ crash-diagnostics run --file Diagnostics.file --args "username=foo, ssh_port=1234"
```