### PR TITLE
Starlark - Better argument handling with `starlark.UnpackArgs`

### DIFF
--- a/ssh/scp.go
+++ b/ssh/scp.go
@@ -38,7 +38,7 @@ func CopyFrom(args SSHArgs, rootDir string, sourcePath string) error {
 
 	sshCmd, err := makeSCPCmdStr(prog, args, sourcePath)
 	if err != nil {
-		logrus.Debug()
+		return fmt.Errorf("scp: failed to build command string: %s", err)
 	}
 
 	effectiveCmd := fmt.Sprintf(`%s "%s"`, sshCmd, targetPath)

--- a/starlark/capture_local.go
+++ b/starlark/capture_local.go
@@ -24,7 +24,7 @@ func captureLocalFunc(thread *starlark.Thread, b *starlark.Builtin, args starlar
 		"file_name?", &fileName,
 		"desc?", &desc,
 	); err != nil {
-		return starlark.None, err
+		return starlark.None, fmt.Errorf("%s: %s", identifiers.captureLocal, err)
 	}
 
 	if len(workdir) == 0 {

--- a/starlark/crashd_config_test.go
+++ b/starlark/crashd_config_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
 )
 
@@ -27,7 +26,7 @@ func testCrashdConfigFunc(t *testing.T) {
 	}{
 		{
 			name:   "crash_config saved in thread",
-			script: `crashd_config(foo="fooval", bar="barval")`,
+			script: `crashd_config(workdir="fooval", default_shell="barval")`,
 			eval: func(t *testing.T, script string) {
 				exe := New()
 				if err := exe.Exec("test.star", strings.NewReader(script)); err != nil {
@@ -41,22 +40,16 @@ func testCrashdConfigFunc(t *testing.T) {
 				if !ok {
 					t.Fatalf("unexpected type for thread local key configs.crashd: %T", data)
 				}
-				if len(cfg.AttrNames()) != 2 {
+				if len(cfg.AttrNames()) != 5 {
 					t.Fatalf("unexpected item count in configs.crashd: %d", len(cfg.AttrNames()))
 				}
-				val, err := cfg.Attr("foo")
-				if err != nil {
-					t.Fatalf("key 'foo' not found in crashd_config: %s", err)
-				}
-				if trimQuotes(val.String()) != "fooval" {
-					t.Fatalf("unexpected value for key 'foo': %s", val.String())
-				}
+
 			},
 		},
 
 		{
 			name:   "crash_config returned value",
-			script: `cfg = crashd_config(foo="fooval", bar="barval")`,
+			script: `cfg = crashd_config(uid="fooval", gid="barval")`,
 			eval: func(t *testing.T, script string) {
 				exe := New()
 				if err := exe.Exec("test.star", strings.NewReader(script)); err != nil {
@@ -65,10 +58,6 @@ func testCrashdConfigFunc(t *testing.T) {
 				data := exe.result["cfg"]
 				if data == nil {
 					t.Fatal("crashd_config function not returning value")
-				}
-				_, ok := data.(starlark.NoneType)
-				if !ok {
-					t.Fatalf("crashd_config should not return a value, but returned a %T", data)
 				}
 			},
 		},
@@ -90,7 +79,7 @@ func testCrashdConfigFunc(t *testing.T) {
 				if !ok {
 					t.Fatalf("unexpected type for thread local key crashd_config: %T", data)
 				}
-				if len(cfg.AttrNames()) != 4 {
+				if len(cfg.AttrNames()) != 5 {
 					t.Fatalf("unexpected item count in configs.crashd: %d", len(cfg.AttrNames()))
 				}
 				val, err := cfg.Attr("uid")

--- a/starlark/hostlist_provider_test.go
+++ b/starlark/hostlist_provider_test.go
@@ -19,7 +19,7 @@ func TestHostListProvider(t *testing.T) {
 	}{
 		{
 			name:   "single host",
-			script: `provider = host_list_provider(hosts="foo.host")`,
+			script: `provider = host_list_provider(hosts=["foo.host"])`,
 			eval: func(t *testing.T, script string) {
 				exe := New()
 				if err := exe.Exec("test.star", strings.NewReader(script)); err != nil {

--- a/starlark/kube_config.go
+++ b/starlark/kube_config.go
@@ -4,23 +4,27 @@
 package starlark
 
 import (
+	"fmt"
+
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
 )
 
 // kubeConfigFn is built-in starlark function that wraps the kwargs into a dictionary value.
 // The result is also added to the thread for other built-in to access.
+// Starlark: kube_config(path=kubecf/path)
 func kubeConfigFn(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var dictionary starlark.StringDict
-
-	if kwargs != nil {
-		dict, err := kwargsToStringDict(kwargs)
-		if err != nil {
-			return starlark.None, err
-		}
-		dictionary = dict
+	var path string
+	if err := starlark.UnpackArgs(
+		identifiers.crashdCfg, args, kwargs,
+		"path", &path,
+	); err != nil {
+		return starlark.None, fmt.Errorf("%s: %s", identifiers.kubeCfg, err)
 	}
-	structVal := starlarkstruct.FromStringDict(starlarkstruct.Default, dictionary)
+
+	structVal := starlarkstruct.FromStringDict(starlarkstruct.Default, starlark.StringDict{
+		"path": starlark.String(path),
+	})
 
 	// save dict to be used as default
 	thread.SetLocal(identifiers.kubeCfg, structVal)

--- a/starlark/resources_test.go
+++ b/starlark/resources_test.go
@@ -55,7 +55,7 @@ func TestResourcesFunc(t *testing.T) {
 			name: "host only",
 			kwargs: func(t *testing.T) []starlark.Tuple {
 				return []starlark.Tuple{
-					[]starlark.Value{starlark.String("hosts"), starlark.String("foo.host.1")},
+					[]starlark.Value{starlark.String("hosts"), starlark.NewList([]starlark.Value{starlark.String("foo.host.1")})},
 				}
 			},
 			eval: func(t *testing.T, kwargs []starlark.Tuple) {
@@ -113,15 +113,18 @@ func TestResourcesFunc(t *testing.T) {
 		{
 			name: "provider only",
 			kwargs: func(t *testing.T) []starlark.Tuple {
-				provider, err := newHostListProvider(
+				provider, err := hostListProvider(
 					newTestThreadLocal(t),
-					starlark.StringDict{"hosts": starlark.NewList(
-						[]starlark.Value{
+					nil, nil,
+					[]starlark.Tuple{{
+						starlark.String("hosts"),
+						starlark.NewList([]starlark.Value{
 							starlark.String("local.host"),
 							starlark.String("192.168.10.10"),
-						},
-					)},
+						}),
+					}},
 				)
+
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -197,7 +200,7 @@ func TestResourceScript(t *testing.T) {
 	}{
 		{
 			name:   "default resource with host",
-			script: `resources(hosts="foo.host.1")`,
+			script: `resources(hosts=["foo.host.1"])`,
 			eval: func(t *testing.T, script string) {
 				exe := New()
 				if err := exe.Exec("test.star", strings.NewReader(script)); err != nil {

--- a/starlark/ssh_config_test.go
+++ b/starlark/ssh_config_test.go
@@ -39,9 +39,6 @@ func TestSSHConfigFunc(t *testing.T) {
 				if !ok {
 					t.Fatalf("unexpected type for thread local key ssh_config: %T", data)
 				}
-				if len(cfg.AttrNames()) != 4 {
-					t.Fatalf("unexpected item count in ssh_config: %d", len(cfg.AttrNames()))
-				}
 				val, err := cfg.Attr("username")
 				if err != nil {
 					t.Fatal(err)
@@ -67,9 +64,6 @@ func TestSSHConfigFunc(t *testing.T) {
 				cfg, ok := data.(*starlarkstruct.Struct)
 				if !ok {
 					t.Fatalf("unexpected type for thread local key ssh_config: %T", data)
-				}
-				if len(cfg.AttrNames()) != 4 {
-					t.Fatalf("unexpected item count in ssh_config: %d", len(cfg.AttrNames()))
 				}
 				val, err := cfg.Attr("private_key_path")
 				if err != nil {
@@ -98,7 +92,7 @@ func TestSSHConfigFunc(t *testing.T) {
 				if !ok {
 					t.Fatalf("unexpected type for thread local key ssh_config: %T", data)
 				}
-				if len(cfg.AttrNames()) != 5 {
+				if len(cfg.AttrNames()) != 7 {
 					t.Fatalf("unexpected item count in ssh_config: %d", len(cfg.AttrNames()))
 				}
 			},

--- a/starlark/starlark_exec.go
+++ b/starlark/starlark_exec.go
@@ -35,7 +35,7 @@ func (e *Executor) AddPredeclared(name string, value starlark.Value) {
 
 func (e *Executor) Exec(name string, source io.Reader) error {
 	if err := setupLocalDefaults(e.thread); err != nil {
-		return fmt.Errorf("crashd failed: %s", err)
+		return fmt.Errorf("failed to setup defaults: %s", err)
 	}
 
 	result, err := starlark.ExecFile(e.thread, name, source, e.predecs)

--- a/starlark/starlark_exec_test.go
+++ b/starlark/starlark_exec_test.go
@@ -4,48 +4,9 @@
 package starlark
 
 import (
-	"strings"
 	"testing"
 )
 
 func TestExec(t *testing.T) {
-	tests := []struct {
-		name   string
-		script string
-		eval   func(t *testing.T, script string)
-	}{
-		{
-			name:   "crash_config only",
-			script: `crashd_config()`,
-			eval: func(t *testing.T, script string) {
-				if err := New().Exec("test.file", strings.NewReader(script)); err != nil {
-					t.Fatal(err)
-				}
-			},
-		},
-		{
-			name:   "kube_config only",
-			script: `kube_config()`,
-			eval: func(t *testing.T, script string) {
-				if err := New().Exec("test.file", strings.NewReader(script)); err != nil {
-					t.Fatal(err)
-				}
-			},
-		},
-		{
-			name:   "kube_config only",
-			script: `kube_config()`,
-			eval: func(t *testing.T, script string) {
-				if err := New().Exec("test.file", strings.NewReader(script)); err != nil {
-					t.Fatal(err)
-				}
-			},
-		},
-	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			test.eval(t, test.script)
-		})
-	}
 }


### PR DESCRIPTION
This PR updates the code to use `starlark.UnpackArgs` for better handling of script arguments when executing Go built-in starlark functions.

See #103 