### PR TITLE
Implementation of the archive script function

### DIFF
--- a/starlark/archive.go
+++ b/starlark/archive.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package starlark
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+
+	"github.com/vmware-tanzu/crash-diagnostics/archiver"
+)
+
+// archiveFunc is a built-in starlark function that bundles specified directories into
+// an arhive format (i.e. tar.gz)
+// Starlark format: archive(file_name=<file name> ,source_paths=list)
+func archiveFunc(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var outputFile string
+	var paths *starlark.List
+
+	if err := starlark.UnpackArgs(
+		identifiers.archive, args, kwargs,
+		"output_file?", &outputFile,
+		"source_paths", &paths,
+	); err != nil {
+		return starlark.None, fmt.Errorf("%s: %s", identifiers.archive, err)
+	}
+
+	if len(outputFile) == 0 {
+		outputFile = "archive.tar.gz"
+	}
+
+	if paths != nil && paths.Len() == 0 {
+		return starlark.None, fmt.Errorf("%s: one or more paths required", identifiers.archive)
+	}
+
+	if err := archiver.Tar(outputFile, getPathElements(paths)...); err != nil {
+		return starlark.None, fmt.Errorf("%s failed: %s", identifiers.archive, err)
+	}
+
+	return starlark.String(outputFile), nil
+}
+
+func getPathElements(paths *starlark.List) []string {
+	pathElems := []string{}
+	for i := 0; i < paths.Len(); i++ {
+		if val, ok := paths.Index(i).(starlark.String); ok {
+			pathElems = append(pathElems, string(val))
+		}
+	}
+	return pathElems
+}

--- a/starlark/archive_test.go
+++ b/starlark/archive_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package starlark
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"go.starlark.net/starlark"
+)
+
+func TestArchiveFunc(t *testing.T) {
+	tests := []struct {
+		name string
+		args func(t *testing.T) []starlark.Tuple
+		eval func(t *testing.T, kwargs []starlark.Tuple)
+	}{
+		{
+			name: "arhive single file",
+			args: func(t *testing.T) []starlark.Tuple {
+				return []starlark.Tuple{
+					{starlark.String("output_file"), starlark.String("/tmp/out.tar.gz")},
+					{starlark.String("source_paths"), starlark.NewList([]starlark.Value{starlark.String(defaults.workdir)})},
+				}
+			},
+			eval: func(t *testing.T, kwargs []starlark.Tuple) {
+				val, err := archiveFunc(newTestThreadLocal(t), nil, nil, kwargs)
+				if err != nil {
+					t.Fatal(err)
+				}
+				expected := "/tmp/out.tar.gz"
+				defer func() {
+					os.RemoveAll(expected)
+					os.RemoveAll(defaults.workdir)
+				}()
+
+				result := ""
+				if r, ok := val.(starlark.String); ok {
+					result = string(r)
+				}
+				if result != expected {
+					t.Errorf("unexpected result: %s", result)
+				}
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.eval(t, test.args(t))
+		})
+	}
+}
+
+func TestArchiveScript(t *testing.T) {
+	tests := []struct {
+		name   string
+		script string
+		eval   func(t *testing.T, script string)
+	}{
+		{
+			name: "archive defaults",
+			script: `
+result = archive(output_file="/tmp/archive.tar.gz", source_paths=["/tmp/crashd"])
+`,
+			eval: func(t *testing.T, script string) {
+				exe := New()
+				if err := exe.Exec("test.star", strings.NewReader(script)); err != nil {
+					t.Fatal(err)
+				}
+
+				expected := "/tmp/archive.tar.gz"
+				var result string
+				resultVal := exe.result["result"]
+				if resultVal == nil {
+					t.Fatal("archive() should be assigned to a variable for test")
+				}
+				res, ok := resultVal.(starlark.String)
+				if !ok {
+					t.Fatal("archive() should return a string")
+				}
+				result = string(res)
+				defer func() {
+					os.RemoveAll(result)
+					os.RemoveAll(defaults.workdir)
+				}()
+
+				if result != expected {
+					t.Errorf("unexpected result: %s", result)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.eval(t, test.script)
+		})
+	}
+}

--- a/starlark/crashd_config_test.go
+++ b/starlark/crashd_config_test.go
@@ -28,6 +28,7 @@ func testCrashdConfigFunc(t *testing.T) {
 			name:   "crash_config saved in thread",
 			script: `crashd_config(workdir="fooval", default_shell="barval")`,
 			eval: func(t *testing.T, script string) {
+				defer os.RemoveAll("fooval")
 				exe := New()
 				if err := exe.Exec("test.star", strings.NewReader(script)); err != nil {
 					t.Fatal(err)

--- a/starlark/starlark_exec.go
+++ b/starlark/starlark_exec.go
@@ -81,6 +81,7 @@ func newPredeclareds() starlark.StringDict {
 		identifiers.sshCfg:            starlark.NewBuiltin(identifiers.sshCfg, sshConfigFn),
 		identifiers.hostListProvider:  starlark.NewBuiltin(identifiers.hostListProvider, hostListProvider),
 		identifiers.resources:         starlark.NewBuiltin(identifiers.resources, resourcesFunc),
+		identifiers.archive:           starlark.NewBuiltin(identifiers.archive, archiveFunc),
 		identifiers.run:               starlark.NewBuiltin(identifiers.run, runFunc),
 		identifiers.runLocal:          starlark.NewBuiltin(identifiers.runLocal, runLocalFunc),
 		identifiers.capture:           starlark.NewBuiltin(identifiers.capture, captureFunc),

--- a/starlark/support.go
+++ b/starlark/support.go
@@ -38,6 +38,7 @@ var (
 		capture          string
 		captureLocal     string
 		copyFrom         string
+		archive          string
 
 		kubeCapture       string
 		kubeGet           string
@@ -62,6 +63,7 @@ var (
 		capture:          "capture",
 		captureLocal:     "capture_local",
 		copyFrom:         "copy_from",
+		archive:          "archive",
 
 		kubeCapture:       "kube_capture",
 		kubeGet:           "kube_get",
@@ -91,7 +93,6 @@ var (
 		pkPath: func() string {
 			return filepath.Join(os.Getenv("HOME"), ".ssh", "id_rsa")
 		}(),
-		outPath:     "./crashd.tar.gz",
 		connRetries: 30,
 		connTimeout: 30,
 	}


### PR DESCRIPTION
This PR implements #110 
The archive function allows script developers to bundle arbitrary directories to create compressed bundles (tar.gz)