### PR TITLE
Unpacking kube directive arguments via Starlark library function

### DIFF
--- a/starlark/kube_capture_test.go
+++ b/starlark/kube_capture_test.go
@@ -44,7 +44,7 @@ var _ = Describe("kube_capture", func() {
 		crashdScript := fmt.Sprintf(`
 crashd_config(workdir="%s")
 kube_config(path="%s")
-kube_data = kube_capture(what="objects", groups="core", kinds="services", namespaces=["default", "kube-system"])
+kube_data = kube_capture(what="objects", groups=["core"], kinds=["services"], namespaces=["default", "kube-system"])
 		`, workdir, k8sconfig)
 		execSetup(crashdScript)
 		Expect(err).NotTo(HaveOccurred())
@@ -74,7 +74,7 @@ kube_data = kube_capture(what="objects", groups="core", kinds="services", namesp
 		crashdScript := fmt.Sprintf(`
 crashd_config(workdir="%s")
 kube_config(path="%s")
-kube_data = kube_capture(what="objects", groups="core", kinds="nodes")
+kube_data = kube_capture(what="objects", groups=["core"], kinds=["nodes"])
 		`, workdir, k8sconfig)
 		execSetup(crashdScript)
 		Expect(err).NotTo(HaveOccurred())
@@ -101,7 +101,7 @@ kube_data = kube_capture(what="objects", groups="core", kinds="nodes")
 		crashdScript := fmt.Sprintf(`
 crashd_config(workdir="%s")
 kube_config(path="%s")
-kube_data = kube_capture(what="logs", namespaces="kube-system")
+kube_data = kube_capture(what="logs", namespaces=["kube-system"])
 		`, workdir, k8sconfig)
 		execSetup(crashdScript)
 		Expect(err).NotTo(HaveOccurred())
@@ -132,7 +132,7 @@ kube_data = kube_capture(what="logs", namespaces="kube-system")
 		crashdScript := fmt.Sprintf(`
 crashd_config(workdir="%s")
 kube_config(path="%s")
-kube_data = kube_capture(what="logs", namespaces="kube-system", containers=["etcd"])
+kube_data = kube_capture(what="logs", namespaces=["kube-system"], containers=["etcd"])
 		`, workdir, k8sconfig)
 		execSetup(crashdScript)
 		Expect(err).NotTo(HaveOccurred())
@@ -165,9 +165,9 @@ kube_data = kube_capture(what="logs", namespaces="kube-system", containers=["etc
 	},
 		Entry("in global thread", fmt.Sprintf(`
 kube_config(path="%s")
-kube_capture(what="logs", namespaces="kube-system", containers=["etcd"])`, "/foo/bar")),
+kube_capture(what="logs", namespaces=["kube-system"], containers=["etcd"])`, "/foo/bar")),
 		Entry("in function call", fmt.Sprintf(`
 cfg = kube_config(path="%s")
-kube_capture(what="logs", namespaces="kube-system", containers=["etcd"], kube_config=cfg)`, "/foo/bar")),
+kube_capture(what="logs", namespaces=["kube-system"], containers=["etcd"], kube_config=cfg)`, "/foo/bar")),
 	)
 })

--- a/starlark/kube_config.go
+++ b/starlark/kube_config.go
@@ -75,27 +75,6 @@ func addDefaultKubeConf(thread *starlark.Thread) error {
 	return nil
 }
 
-// getKubeConfigPath is responsible to obtain the path to the kubeconfig
-// It checks for the `path` key in the input args for the directive otherwise
-// falls back to the default kube_config from the thread context
-func getKubeConfigPath(thread *starlark.Thread, structVal *starlarkstruct.Struct) (string, error) {
-	var (
-		err   error
-		kcVal starlark.Value
-	)
-
-	if kcVal, err = structVal.Attr("kube_config"); err != nil {
-		kubeConfigData := thread.Local(identifiers.kubeCfg)
-		kcVal = kubeConfigData.(starlark.Value)
-	}
-
-	kubeConfigVal, ok := kcVal.(*starlarkstruct.Struct)
-	if !ok {
-		return "", err
-	}
-	return getKubeConfigFromStruct(kubeConfigVal)
-}
-
 func getKubeConfigFromStruct(kubeConfigStructVal *starlarkstruct.Struct) (string, error) {
 	kvPathVal, err := kubeConfigStructVal.Attr("path")
 	if err != nil {

--- a/starlark/kube_get.go
+++ b/starlark/kube_get.go
@@ -11,24 +11,47 @@ import (
 )
 
 // KubeGetFn is a starlark built-in for the fetching kubernetes objects
-func KubeGetFn(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func KubeGetFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var objects *starlark.List
+	var groups, kinds, namespaces, versions, names, labels, containers *starlark.List
+	var kubeConfig *starlarkstruct.Struct
 
-	structVal, err := kwargsToStruct(kwargs)
-	if err != nil {
-		return starlark.None, err
+	if err := starlark.UnpackArgs(
+		identifiers.crashdCfg, args, kwargs,
+		"groups?", &groups,
+		"kinds?", &kinds,
+		"namespaces?", &namespaces,
+		"versions?", &versions,
+		"names?", &names,
+		"labels?", &labels,
+		"containers?", &containers,
+		"kube_config?", &kubeConfig,
+	); err != nil {
+		return starlark.None, errors.Wrap(err, "failed to read args")
 	}
 
-	kubeconfig, err := getKubeConfigPath(thread, structVal)
+	if kubeConfig == nil {
+		kubeConfig = thread.Local(identifiers.kubeCfg).(*starlarkstruct.Struct)
+	}
+	path, err := getKubeConfigFromStruct(kubeConfig)
 	if err != nil {
 		return starlark.None, errors.Wrap(err, "failed to kubeconfig")
 	}
-	client, err := k8s.New(kubeconfig)
+
+	client, err := k8s.New(path)
 	if err != nil {
 		return starlark.None, errors.Wrap(err, "could not initialize search client")
 	}
 
-	searchParams := k8s.NewSearchParams(structVal)
+	searchParams := k8s.SearchParams{
+		Groups:     toSlice(groups),
+		Kinds:      toSlice(kinds),
+		Namespaces: toSlice(namespaces),
+		Versions:   toSlice(versions),
+		Names:      toSlice(names),
+		Labels:     toSlice(labels),
+		Containers: toSlice(containers),
+	}
 	searchResults, err := client.Search(searchParams)
 	if err == nil {
 		objects = starlark.NewList([]starlark.Value{})

--- a/starlark/kube_get_test.go
+++ b/starlark/kube_get_test.go
@@ -30,7 +30,7 @@ var _ = Describe("kube_get", func() {
 	It("returns a list of k8s services as starlark objects", func() {
 		crashdScript := fmt.Sprintf(`
 kube_config(path="%s")
-kube_get_data = kube_get(groups="core", kinds="services", namespaces=["default", "kube-system"])
+kube_get_data = kube_get(groups=["core"], kinds=["services"], namespaces=["default", "kube-system"])
 		`, k8sconfig)
 		execSetup(crashdScript)
 		Expect(err).NotTo(HaveOccurred())
@@ -52,7 +52,7 @@ kube_get_data = kube_get(groups="core", kinds="services", namespaces=["default",
 	It("returns a list of k8s nodes as starlark objects", func() {
 		crashdScript := fmt.Sprintf(`
 kube_config(path="%s")
-kube_get_data = kube_get(groups="core", kinds="nodes")
+kube_get_data = kube_get(groups=["core"], kinds=["nodes"])
 			`, k8sconfig)
 		execSetup(crashdScript)
 		Expect(err).NotTo(HaveOccurred())
@@ -74,7 +74,7 @@ kube_get_data = kube_get(groups="core", kinds="nodes")
 	It("returns a list of etcd containers as starlark objects", func() {
 		crashdScript := fmt.Sprintf(`
 kube_config(path="%s")
-kube_get_data = kube_get(namespaces="kube-system", containers=["etcd"])
+kube_get_data = kube_get(namespaces=["kube-system"], containers=["etcd"])
 			`, k8sconfig)
 		execSetup(crashdScript)
 		Expect(err).NotTo(HaveOccurred())
@@ -99,9 +99,9 @@ kube_get_data = kube_get(namespaces="kube-system", containers=["etcd"])
 	},
 		Entry("in global thread", fmt.Sprintf(`
 kube_config(path="%s")
-kube_get(namespaces="kube-system", containers=["etcd"])`, "/foo/bar")),
+kube_get(namespaces=["kube-system"], containers=["etcd"])`, "/foo/bar")),
 		Entry("in function call", fmt.Sprintf(`
 cfg = kube_config(path="%s")
-kube_get(namespaces="kube-system", containers=["etcd"], kube_config=cfg)`, "/foo/bar")),
+kube_get(namespaces=["kube-system"], containers=["etcd"], kube_config=cfg)`, "/foo/bar")),
 	)
 })

--- a/starlark/kube_nodes_provider.go
+++ b/starlark/kube_nodes_provider.go
@@ -4,8 +4,6 @@
 package starlark
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/vmware-tanzu/crash-diagnostics/k8s"
 
@@ -15,24 +13,43 @@ import (
 
 // KubeNodesProviderFn is a built-in starlark function that collects compute resources from a k8s cluster
 // Starlark format: kube_nodes_provider([kube_config=kube_config(), ssh_config=ssh_config(), names=["foo", "bar], labels=["bar", "baz"]])
-func KubeNodesProviderFn(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func KubeNodesProviderFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 
-	structVal, err := kwargsToStruct(kwargs)
-	if err != nil {
-		return starlark.None, err
+	var names, labels *starlark.List
+	var kubeConfig, sshConfig *starlarkstruct.Struct
+
+	if err := starlark.UnpackArgs(
+		identifiers.crashdCfg, args, kwargs,
+		"names?", &names,
+		"labels?", &labels,
+		"kube_config?", &kubeConfig,
+		"ssh_config?", &sshConfig,
+	); err != nil {
+		return starlark.None, errors.Wrap(err, "failed to read args")
 	}
 
-	return newKubeNodesProvider(thread, structVal)
+	if kubeConfig == nil {
+		kubeConfig = thread.Local(identifiers.kubeCfg).(*starlarkstruct.Struct)
+	}
+	path, err := getKubeConfigFromStruct(kubeConfig)
+	if err != nil {
+		return starlark.None, errors.Wrap(err, "failed to kubeconfig")
+	}
+
+	if sshConfig == nil {
+		sshConfig = thread.Local(identifiers.sshCfg).(*starlarkstruct.Struct)
+	}
+
+	return newKubeNodesProvider(path, sshConfig, toSlice(names), toSlice(labels))
 }
 
 // newKubeNodesProvider returns a struct with k8s cluster node provider info
-func newKubeNodesProvider(thread *starlark.Thread, structVal *starlarkstruct.Struct) (*starlarkstruct.Struct, error) {
-	kubeconfig, err := getKubeConfigPath(thread, structVal)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to kubeconfig")
-	}
+func newKubeNodesProvider(kubeconfig string, sshConfig *starlarkstruct.Struct, names, labels []string) (*starlarkstruct.Struct, error) {
 
-	searchParams := generateSearchParams(structVal)
+	searchParams := k8s.SearchParams{
+		Names:  names,
+		Labels: labels,
+	}
 	nodeAddresses, err := k8s.GetNodeAddresses(kubeconfig, searchParams.Names, searchParams.Labels)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not fetch node addresses")
@@ -40,8 +57,9 @@ func newKubeNodesProvider(thread *starlark.Thread, structVal *starlarkstruct.Str
 
 	// dictionary for node provider struct
 	kubeNodesProviderDict := starlark.StringDict{
-		"kind":      starlark.String(identifiers.kubeNodesProvider),
-		"transport": starlark.String("ssh"),
+		"kind":             starlark.String(identifiers.kubeNodesProvider),
+		"transport":        starlark.String("ssh"),
+		identifiers.sshCfg: sshConfig,
 	}
 
 	// add node info to dictionary
@@ -51,27 +69,5 @@ func newKubeNodesProvider(thread *starlark.Thread, structVal *starlarkstruct.Str
 	}
 	kubeNodesProviderDict["hosts"] = starlark.NewList(nodeIps)
 
-	// add ssh info to dictionary
-	if _, ok := kubeNodesProviderDict[identifiers.sshCfg]; !ok {
-		data := thread.Local(identifiers.sshCfg)
-		sshcfg, ok := data.(*starlarkstruct.Struct)
-		if !ok {
-			return nil, fmt.Errorf("%s: default ssh_config not found", identifiers.kubeNodesProvider)
-		}
-		kubeNodesProviderDict[identifiers.sshCfg] = sshcfg
-	}
-
 	return starlarkstruct.FromStringDict(starlarkstruct.Default, kubeNodesProviderDict), nil
-}
-
-func generateSearchParams(structVal *starlarkstruct.Struct) k8s.SearchParams {
-	// change nodes key to names
-	if _, err := structVal.Attr("nodes"); err == nil {
-		dict := starlark.StringDict{}
-		structVal.ToStringDict(dict)
-
-		dict["names"] = dict["nodes"]
-		structVal = starlarkstruct.FromStringDict(starlarkstruct.Default, dict)
-	}
-	return k8s.NewSearchParams(structVal)
 }


### PR DESCRIPTION
Use the starlark provided UnpackArgs function to fetch arguments for the `kube_get`, `kube_capture` and `kube_nodes_provider` directives.