### PR TITLE
Adds the set_as_default directive

### DIFF
--- a/examples/capv_provider.star
+++ b/examples/capv_provider.star
@@ -22,11 +22,12 @@ capture(cmd="sudo cat /var/log/cloud-init.log", resources=nodes)
 
 #add code to collect pod info from cluster
 wc_kube_conf = kube_config(capi_provider = wc_provider)
+set_as_default(kube_config = wc_kube_conf)
 
 pod_ns=["default", "kube-system"]
 
-kube_capture(what="logs", namespaces=pod_ns, kube_config=wc_kube_conf)
-kube_capture(what="objects", kinds=["pods", "services"], namespaces=pod_ns, kube_config=wc_kube_conf)
-kube_capture(what="objects", kinds=["deployments", "replicasets"], groups=["apps"], namespaces=pod_ns, kube_config=wc_kube_conf)
+kube_capture(what="logs", namespaces=pod_ns)
+kube_capture(what="objects", kinds=["pods", "services"], namespaces=pod_ns)
+kube_capture(what="objects", kinds=["deployments", "replicasets"], groups=["apps"], namespaces=pod_ns)
 
 archive(output_file="diagnostics.tar.gz", source_paths=[conf.workdir])

--- a/examples/kind-api-objects.star
+++ b/examples/kind-api-objects.star
@@ -10,8 +10,7 @@ nspaces=[
     "cert-manager tkg-system",
 ]
 
-
-kube_config(path=args.kubecfg)
+set_as_default(kube_config = kube_config(path=args.kubecfg))
 
 # capture Kubernetes API object and store in files (under working dir)
 kube_capture(what="objects", kinds=["services", "pods"], namespaces=nspaces)

--- a/examples/kind-capi-bootstrap.star
+++ b/examples/kind-capi-bootstrap.star
@@ -28,12 +28,12 @@ nspaces=[
     "cert-manager tkg-system",
 ]
 
-kconf=kube_config(path=kind_cfg)
+kconf = kube_config(path=kind_cfg)
 
 # capture Kubernetes API object and store in files (under working dir)
-kube_capture(what="objects", kinds=["services", "pods"], namespaces=nspaces, kube_conf=kconf)
-kube_capture(what="objects", kinds=["deployments", "replicasets"], namespaces=nspaces, kube_conf=kconf)
-kube_capture(what="objects", kinds=["clusters", "machines", "machinesets", "machinedeployments"], namespaces="tkg-system", kube_conf=kconf)
+kube_capture(what="objects", kinds=["services", "pods"], namespaces=nspaces, kube_config = kconf)
+kube_capture(what="objects", kinds=["deployments", "replicasets"], namespaces=nspaces, kube_config = kconf)
+kube_capture(what="objects", kinds=["clusters", "machines", "machinesets", "machinedeployments"], namespaces="tkg-system", kube_config = kconf)
 
 # bundle files stored in working dir
 archive(output_file="/tmp/crashout.tar.gz", source_paths=[conf.workdir])

--- a/examples/pod-logs.star
+++ b/examples/pod-logs.star
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 conf=crashd_config(workdir="/tmp/crashlogs")
-kube_config(path="{0}/.kube/config".format(os.home))
+set_as_default(kube_config = kube_config(path="{0}/.kube/config".format(os.home)))
 kube_capture(what="logs", namespaces=["default", "cert-manager", "tkg-system"])
 
 # bundle files stored in working dir

--- a/examples/script-args.star
+++ b/examples/script-args.star
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 conf=crashd_config(workdir=args.workdir)
-kube_config(path=args.kubecfg)
-kube_capture(what="logs", namespaces=["default", "cert-manager", "tkg-system"])
+kube_capture(what="logs", namespaces=["default", "cert-manager", "tkg-system"], kube_config = kube_config(path=args.kubecfg))
 
 # bundle files stored in working dir
 archive(output_file=args.output, source_paths=[args.workdir])

--- a/starlark/capture_test.go
+++ b/starlark/capture_test.go
@@ -182,8 +182,7 @@ func testCaptureFuncScriptForHostResources(t *testing.T, port string) {
 		{
 			name: "default cmd multiple machines",
 			script: fmt.Sprintf(`
-ssh_config(username=os.username, port="%s")
-resources(hosts=["127.0.0.1","localhost"])
+set_as_default(resources = resources(provider = host_list_provider(hosts=["127.0.0.1","localhost"], ssh_config = ssh_config(username=os.username, port="%s"))))
 result = capture("echo 'Hello World!'")`, port),
 			eval: func(t *testing.T, script string) {
 				exe := New()
@@ -229,7 +228,7 @@ def exec(hosts):
 	return result
 		
 # configuration
-ssh_config(username=os.username, port="%s")
+set_as_default(ssh_config = ssh_config(username=os.username, port="%s"))
 hosts = resources(provider=host_list_provider(hosts=["127.0.0.1","localhost"]))
 result = exec(hosts)`, port),
 			eval: func(t *testing.T, script string) {

--- a/starlark/copy_from_test.go
+++ b/starlark/copy_from_test.go
@@ -233,8 +233,7 @@ func testCopyFuncScriptForHostResources(t *testing.T, port string) {
 			name:        "multiple machines single copyFrom",
 			remoteFiles: map[string]string{"foobar.c": "footext", "bar/bar.txt": "BarBar", "bar/foo.txt": "FooBar", "bar/baz.csv": "BizzBuzz"},
 			script: fmt.Sprintf(`
-ssh_config(username=os.username, port="%s")
-resources(hosts=["127.0.0.1","localhost"])
+set_as_default(resources = resources(provider = host_list_provider(hosts=["127.0.0.1","localhost"], ssh_config = ssh_config(username=os.username, port="%s"))))
 result = copy_from("bar/foo.txt")`, port),
 			eval: func(t *testing.T, script string) {
 				exe := New()
@@ -298,7 +297,7 @@ def cp(hosts):
 		return result
 		
 # configuration
-ssh_config(username=os.username, port="%s")
+set_as_default(ssh_config = ssh_config(username=os.username, port="%s"))
 hosts = resources(provider=host_list_provider(hosts=["127.0.0.1","localhost"]))
 result = cp(hosts)`, port),
 			eval: func(t *testing.T, script string) {

--- a/starlark/hostlist_provider_test.go
+++ b/starlark/hostlist_provider_test.go
@@ -19,7 +19,7 @@ func TestHostListProvider(t *testing.T) {
 	}{
 		{
 			name:   "single host",
-			script: `provider = host_list_provider(hosts=["foo.host"])`,
+			script: `provider = host_list_provider(hosts=["foo.host"], ssh_config = ssh_config(username="uname", private_key_path="path"))`,
 			eval: func(t *testing.T, script string) {
 				exe := New()
 				if err := exe.Exec("test.star", strings.NewReader(script)); err != nil {
@@ -53,7 +53,7 @@ func TestHostListProvider(t *testing.T) {
 		},
 		{
 			name:   "multiple hosts",
-			script: `provider = host_list_provider(hosts=["foo.host.1", "foo.host.2"])`,
+			script: `provider = host_list_provider(hosts=["foo.host.1", "foo.host.2"], ssh_config = ssh_config(username="uname", private_key_path="path"))`,
 			eval: func(t *testing.T, script string) {
 				exe := New()
 				if err := exe.Exec("test.star", strings.NewReader(script)); err != nil {

--- a/starlark/kube_capture_test.go
+++ b/starlark/kube_capture_test.go
@@ -43,7 +43,7 @@ var _ = Describe("kube_capture", func() {
 	It("creates a directory and files for namespaced objects", func() {
 		crashdScript := fmt.Sprintf(`
 crashd_config(workdir="%s")
-kube_config(path="%s")
+set_as_default(kube_config = kube_config(path="%s"))
 kube_data = kube_capture(what="objects", groups=["core"], kinds=["services"], namespaces=["default", "kube-system"])
 		`, workdir, k8sconfig)
 		execSetup(crashdScript)
@@ -73,8 +73,8 @@ kube_data = kube_capture(what="objects", groups=["core"], kinds=["services"], na
 	It("creates a directory and files for non-namespaced objects", func() {
 		crashdScript := fmt.Sprintf(`
 crashd_config(workdir="%s")
-kube_config(path="%s")
-kube_data = kube_capture(what="objects", groups=["core"], kinds=["nodes"])
+cfg = kube_config(path="%s")
+kube_data = kube_capture(what="objects", groups=["core"], kinds=["nodes"], kube_config = cfg)
 		`, workdir, k8sconfig)
 		execSetup(crashdScript)
 		Expect(err).NotTo(HaveOccurred())
@@ -100,8 +100,7 @@ kube_data = kube_capture(what="objects", groups=["core"], kinds=["nodes"])
 	It("creates a directory and log files for all objects in a namespace", func() {
 		crashdScript := fmt.Sprintf(`
 crashd_config(workdir="%s")
-kube_config(path="%s")
-kube_data = kube_capture(what="logs", namespaces=["kube-system"])
+kube_data = kube_capture(what="logs", namespaces=["kube-system"], kube_config = kube_config(path="%s"))
 		`, workdir, k8sconfig)
 		execSetup(crashdScript)
 		Expect(err).NotTo(HaveOccurred())
@@ -131,8 +130,8 @@ kube_data = kube_capture(what="logs", namespaces=["kube-system"])
 	It("creates a log file for specific container in a namespace", func() {
 		crashdScript := fmt.Sprintf(`
 crashd_config(workdir="%s")
-kube_config(path="%s")
-kube_data = kube_capture(what="logs", namespaces=["kube-system"], containers=["etcd"])
+cfg = kube_config(path="%s")
+kube_data = kube_capture(what="logs", namespaces=["kube-system"], containers=["etcd"], kube_config = cfg)
 		`, workdir, k8sconfig)
 		execSetup(crashdScript)
 		Expect(err).NotTo(HaveOccurred())
@@ -164,8 +163,8 @@ kube_data = kube_capture(what="logs", namespaces=["kube-system"], containers=["e
 		Expect(err).To(HaveOccurred())
 	},
 		Entry("in global thread", fmt.Sprintf(`
-kube_config(path="%s")
-kube_capture(what="logs", namespaces=["kube-system"], containers=["etcd"])`, "/foo/bar")),
+cfg = kube_config(path="%s")
+kube_capture(what="logs", namespaces=["kube-system"], containers=["etcd"], kube_config = cfg)`, "/foo/bar")),
 		Entry("in function call", fmt.Sprintf(`
 cfg = kube_config(path="%s")
 kube_capture(what="logs", namespaces=["kube-system"], containers=["etcd"], kube_config=cfg)`, "/foo/bar")),

--- a/starlark/kube_config.go
+++ b/starlark/kube_config.go
@@ -14,7 +14,7 @@ import (
 // KubeConfigFn is built-in starlark function that wraps the kwargs into a dictionary value.
 // The result is also added to the thread for other built-in to access.
 // Starlark: kube_config(path=kubecf/path)
-func KubeConfigFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func KubeConfigFn(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var path string
 	var provider *starlarkstruct.Struct
 
@@ -53,9 +53,6 @@ func KubeConfigFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tu
 	structVal := starlarkstruct.FromStringDict(starlark.String(identifiers.kubeCfg), starlark.StringDict{
 		"path": starlark.String(path),
 	})
-
-	// save dict to be used as default
-	thread.SetLocal(identifiers.kubeCfg, structVal)
 
 	return structVal, nil
 }

--- a/starlark/kube_config_test.go
+++ b/starlark/kube_config_test.go
@@ -35,17 +35,12 @@ var _ = Describe("kube_config", func() {
 		Context("With kube_config set in the script", func() {
 
 			BeforeEach(func() {
-				crashdScript = `kube_config(path="/foo/bar/kube/config")`
+				crashdScript = `cfg = kube_config(path="/foo/bar/kube/config")`
 				execSetup()
 			})
 
-			It("sets the kube_config in the starlark thread", func() {
-				kubeConfigData := executor.thread.Local(identifiers.kubeCfg)
-				Expect(kubeConfigData).NotTo(BeNil())
-			})
-
 			It("sets the path to the kubeconfig file", func() {
-				kubeConfigData := executor.thread.Local(identifiers.kubeCfg)
+				kubeConfigData := executor.result["cfg"]
 				Expect(kubeConfigData).To(BeAssignableToTypeOf(&starlarkstruct.Struct{}))
 
 				cfg, _ := kubeConfigData.(*starlarkstruct.Struct)
@@ -66,10 +61,8 @@ var _ = Describe("kube_config", func() {
 
 			It("returns the kube config as a result", func() {
 				Expect(executor.result.Has("cfg")).NotTo(BeNil())
-			})
 
-			It("also sets the kube_config in the starlark thread", func() {
-				kubeConfigData := executor.thread.Local(identifiers.kubeCfg)
+				kubeConfigData := executor.result["cfg"]
 				Expect(kubeConfigData).NotTo(BeNil())
 
 				cfg, _ := kubeConfigData.(*starlarkstruct.Struct)
@@ -79,26 +72,24 @@ var _ = Describe("kube_config", func() {
 				Expect(err).To(BeNil())
 				Expect(trimQuotes(val.String())).To(Equal("/foo/bar/kube/config"))
 			})
+
+			It("does not set the kube_config in the starlark thread", func() {
+				kubeConfigData := executor.thread.Local(identifiers.kubeCfg)
+				Expect(kubeConfigData).To(BeNil())
+			})
 		})
 	})
 
-	Context("With default kube_config setup", func() {
+	Context("For default kube_config setup", func() {
 
 		BeforeEach(func() {
 			crashdScript = `foo = "bar"`
 			execSetup()
 		})
 
-		It("sets the default kube_config in the starlark thread", func() {
+		It("does not set the default kube_config in the starlark thread", func() {
 			kubeConfigData := executor.thread.Local(identifiers.kubeCfg)
-			Expect(kubeConfigData).NotTo(BeNil())
-
-			cfg, _ := kubeConfigData.(*starlarkstruct.Struct)
-			Expect(cfg.AttrNames()).To(HaveLen(1))
-
-			val, err := cfg.Attr("path")
-			Expect(err).To(BeNil())
-			Expect(trimQuotes(val.String())).To(ContainSubstring("/.kube/config"))
+			Expect(kubeConfigData).To(BeNil())
 		})
 	})
 })

--- a/starlark/kube_get_test.go
+++ b/starlark/kube_get_test.go
@@ -29,7 +29,7 @@ var _ = Describe("kube_get", func() {
 
 	It("returns a list of k8s services as starlark objects", func() {
 		crashdScript := fmt.Sprintf(`
-kube_config(path="%s")
+set_as_default(kube_config = kube_config(path="%s"))
 kube_get_data = kube_get(groups=["core"], kinds=["services"], namespaces=["default", "kube-system"])
 		`, k8sconfig)
 		execSetup(crashdScript)
@@ -51,8 +51,8 @@ kube_get_data = kube_get(groups=["core"], kinds=["services"], namespaces=["defau
 
 	It("returns a list of k8s nodes as starlark objects", func() {
 		crashdScript := fmt.Sprintf(`
-kube_config(path="%s")
-kube_get_data = kube_get(groups=["core"], kinds=["nodes"])
+cfg = kube_config(path="%s")
+kube_get_data = kube_get(groups=["core"], kinds=["nodes"], kube_config = cfg)
 			`, k8sconfig)
 		execSetup(crashdScript)
 		Expect(err).NotTo(HaveOccurred())
@@ -73,8 +73,7 @@ kube_get_data = kube_get(groups=["core"], kinds=["nodes"])
 
 	It("returns a list of etcd containers as starlark objects", func() {
 		crashdScript := fmt.Sprintf(`
-kube_config(path="%s")
-kube_get_data = kube_get(namespaces=["kube-system"], containers=["etcd"])
+kube_get_data = kube_get(namespaces=["kube-system"], containers=["etcd"], kube_config = kube_config(path="%s"))
 			`, k8sconfig)
 		execSetup(crashdScript)
 		Expect(err).NotTo(HaveOccurred())
@@ -98,7 +97,7 @@ kube_get_data = kube_get(namespaces=["kube-system"], containers=["etcd"])
 		Expect(err).To(HaveOccurred())
 	},
 		Entry("in global thread", fmt.Sprintf(`
-kube_config(path="%s")
+set_as_default(kube_config = kube_config(path="%s"))
 kube_get(namespaces=["kube-system"], containers=["etcd"])`, "/foo/bar")),
 		Entry("in function call", fmt.Sprintf(`
 cfg = kube_config(path="%s")

--- a/starlark/kube_nodes_provider_test.go
+++ b/starlark/kube_nodes_provider_test.go
@@ -27,9 +27,8 @@ var _ = Describe("kube_nodes_provider", func() {
 
 	It("returns a struct with the list of k8s nodes", func() {
 		crashdScript := fmt.Sprintf(`
-kube_config(path="%s")
-ssh_config(username="uname", private_key_path="path")
-provider = kube_nodes_provider()`, k8sconfig)
+cfg = kube_config(path="%s")
+provider = kube_nodes_provider(kube_config = cfg, ssh_config = ssh_config(username="uname", private_key_path="path"))`, k8sconfig)
 		err = execSetup(crashdScript)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -49,9 +48,8 @@ provider = kube_nodes_provider()`, k8sconfig)
 	It("returns a struct with ssh config", func() {
 		crashdScript := fmt.Sprintf(`
 cfg = kube_config(path="%s")
-kube_config(path="/foo/bar")
-ssh_config(username="uname", private_key_path="path")
-provider = kube_nodes_provider(kube_config=cfg)`, k8sconfig)
+ssh_cfg = ssh_config(username="uname", private_key_path="path")
+provider = kube_nodes_provider(kube_config=cfg, ssh_config = ssh_cfg)`, k8sconfig)
 		err = execSetup(crashdScript)
 		Expect(err).NotTo(HaveOccurred())
 

--- a/starlark/resources.go
+++ b/starlark/resources.go
@@ -45,9 +45,6 @@ func resourcesFunc(thread *starlark.Thread, b *starlark.Builtin, args starlark.T
 		return starlark.None, err
 	}
 
-	// save resources for future use
-	thread.SetLocal(identifiers.resources, resources)
-
 	return resources, nil
 }
 

--- a/starlark/set_as_default.go
+++ b/starlark/set_as_default.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package starlark
+
+import (
+	"errors"
+	"fmt"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+// SetAsDefaultFunc is the built-in fn that saves the arguments to the local Starlark thread.
+// Starlark format: set_as_default([ssh_config = ssh_config()][, kube_config = kube_config()][, resources = resources()])
+func SetAsDefaultFunc(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var kubeConfig, sshConfig *starlarkstruct.Struct
+	var resources *starlark.List
+
+	if err := starlark.UnpackArgs(
+		identifiers.setAsDefault, args, kwargs,
+		"kube_config?", &kubeConfig,
+		"ssh_config?", &sshConfig,
+		"resources?", &resources,
+	); err != nil {
+		return starlark.None, fmt.Errorf("%s: %s", identifiers.setAsDefault, err)
+	}
+
+	if sshConfig == nil && kubeConfig == nil && resources == nil {
+		return starlark.None, errors.New("atleast one of kube_config, ssh_config or resources is required")
+	}
+
+	if kubeConfig != nil {
+		thread.SetLocal(identifiers.kubeCfg, kubeConfig)
+	}
+	if sshConfig != nil {
+		thread.SetLocal(identifiers.sshCfg, sshConfig)
+	}
+	if resources != nil {
+		thread.SetLocal(identifiers.resources, resources)
+	}
+
+	return starlark.None, nil
+}

--- a/starlark/set_as_default_test.go
+++ b/starlark/set_as_default_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package starlark
+
+import (
+	"strings"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("set_as_default", func() {
+
+	It("sets the inputs as default", func() {
+		e := New()
+		err := e.Exec("test.set_as_default", strings.NewReader(`
+kube_cfg = kube_config(path="/foo/bar")
+ssh_cfg = ssh_config(username="baz")
+set_as_default(ssh_config = ssh_cfg, kube_config = kube_cfg)
+set_as_default(resources = resources(hosts=["127.0.0.1","localhost"]))
+`))
+		Expect(err).NotTo(HaveOccurred())
+
+		kubeConfig := e.thread.Local(identifiers.kubeCfg)
+		Expect(kubeConfig).NotTo(BeNil())
+		Expect(kubeConfig).To(BeAssignableToTypeOf(&starlarkstruct.Struct{}))
+
+		sshConfig := e.thread.Local(identifiers.sshCfg)
+		Expect(sshConfig).NotTo(BeNil())
+		Expect(sshConfig).To(BeAssignableToTypeOf(&starlarkstruct.Struct{}))
+
+		resources := e.thread.Local(identifiers.resources)
+		Expect(resources).NotTo(BeNil())
+		Expect(resources).To(BeAssignableToTypeOf(&starlark.List{}))
+	})
+
+	Context("When a default ssh_config is not declared", func() {
+
+		It("fails to evaluate resources as a set_as_default option", func() {
+			e := New()
+			err := e.Exec("test.set_as_default", strings.NewReader(`
+ssh_cfg = ssh_config(username="baz")
+set_as_default(resources = resources(hosts=["127.0.0.1","localhost"]), ssh_config = ssh_cfg)
+`))
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	It("throws an error", func() {
+		e := New()
+		err := e.Exec("test.set_as_default", strings.NewReader(`
+kube_cfg = kube_config(path="/foo/bar")
+ssh_cfg = ssh_config(username="baz")
+set_as_default()
+`))
+		Expect(err).To(HaveOccurred())
+
+		kubeConfig := e.thread.Local(identifiers.kubeCfg)
+		Expect(kubeConfig).To(BeNil())
+
+		sshConfig := e.thread.Local(identifiers.sshCfg)
+		Expect(sshConfig).To(BeNil())
+	})
+})

--- a/starlark/ssh_config.go
+++ b/starlark/ssh_config.go
@@ -23,7 +23,7 @@ func addDefaultSSHConf(thread *starlark.Thread) error {
 
 // sshConfigFn is the backing built-in fn that saves and returns its argument as struct value.
 // Starlark format: ssh_config(username=name[, port][, private_key_path][,max_retries][,conn_timeout][,jump_user][,jump_host])
-func sshConfigFn(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func sshConfigFn(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var uname, port, pkPath, jUser, jHost string
 	var maxRetries, connTimeout int
 
@@ -66,9 +66,6 @@ func sshConfigFn(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tup
 		"jump_user":        starlark.String(jUser),
 		"jump_host":        starlark.String(jHost),
 	})
-
-	// save to be used as default when needed
-	thread.SetLocal(identifiers.sshCfg, structVal)
 
 	return structVal, nil
 }

--- a/starlark/ssh_config_test.go
+++ b/starlark/ssh_config_test.go
@@ -25,7 +25,7 @@ func TestSSHConfigFunc(t *testing.T) {
 	}{
 		{
 			name:   "ssh_config saved in thread",
-			script: `ssh_config(username="uname", private_key_path="path")`,
+			script: `set_as_default(ssh_config = ssh_config(username="uname", private_key_path="path"))`,
 			eval: func(t *testing.T, script string) {
 				exe := New()
 				if err := exe.Exec("test.star", strings.NewReader(script)); err != nil {
@@ -84,16 +84,8 @@ func TestSSHConfigFunc(t *testing.T) {
 					t.Fatal(err)
 				}
 				data := exe.thread.Local(identifiers.sshCfg)
-				if data == nil {
-					t.Fatal("default ssh_config not saved in thread local")
-				}
-
-				cfg, ok := data.(*starlarkstruct.Struct)
-				if !ok {
-					t.Fatalf("unexpected type for thread local key ssh_config: %T", data)
-				}
-				if len(cfg.AttrNames()) != 7 {
-					t.Fatalf("unexpected item count in ssh_config: %d", len(cfg.AttrNames()))
+				if data != nil {
+					t.Fatal("default ssh_config present in thread local")
 				}
 			},
 		},

--- a/starlark/starlark_exec.go
+++ b/starlark/starlark_exec.go
@@ -90,5 +90,6 @@ func newPredeclareds() starlark.StringDict {
 		identifiers.kubeGet:           starlark.NewBuiltin(identifiers.kubeGet, KubeGetFn),
 		identifiers.kubeNodesProvider: starlark.NewBuiltin(identifiers.kubeNodesProvider, KubeNodesProviderFn),
 		identifiers.capvProvider:      starlark.NewBuiltin(identifiers.capvProvider, CapvProviderFn),
+		identifiers.setAsDefault:      starlark.NewBuiltin(identifiers.setAsDefault, SetAsDefaultFunc),
 	}
 }

--- a/starlark/support.go
+++ b/starlark/support.go
@@ -40,6 +40,7 @@ var (
 		copyFrom         string
 		archive          string
 		os               string
+		setAsDefault     string
 
 		kubeCapture       string
 		kubeGet           string
@@ -67,6 +68,7 @@ var (
 		copyFrom:         "copy_from",
 		archive:          "archive",
 		os:               "os",
+		setAsDefault:     "set_as_default",
 
 		kubeCapture:       "kube_capture",
 		kubeGet:           "kube_get",


### PR DESCRIPTION
This patch introduces a new starlark directive called as `set_as_default` which can be used to set the default values of one of the three types:
- kube_config
- ssh_config
- resources

Previously, on each call of kube_config, ssh_config or resources, the resulting value was set in the local starlark thread and available inside the script. This patch removes the need for this default behavior. Instead, the script developer needs to make a choice to call the set_as_default directive with the value that needs to be stored in the thread.

Example:
```python
cfg = kube_config(path="/blah/foo/bar")
set_as_default(kube_config = cfg)
```
OR
```python
set_as_default(ssh_config = ssh_config(username="uname", private_key_path="/home/foo/.ssh/id_rsa_custom")
```