### PR TITLE
Fix UnpackArgs inputs for kube functions

### DIFF
--- a/starlark/kube_capture.go
+++ b/starlark/kube_capture.go
@@ -21,7 +21,7 @@ func KubeCaptureFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.T
 	var what string
 
 	if err := starlark.UnpackArgs(
-		identifiers.crashdCfg, args, kwargs,
+		identifiers.kubeCapture, args, kwargs,
 		"what", &what,
 		"groups?", &groups,
 		"kinds?", &kinds,

--- a/starlark/kube_config.go
+++ b/starlark/kube_config.go
@@ -19,7 +19,7 @@ func KubeConfigFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tu
 	var provider *starlarkstruct.Struct
 
 	if err := starlark.UnpackArgs(
-		identifiers.crashdCfg, args, kwargs,
+		identifiers.kubeCfg, args, kwargs,
 		"path?", &path,
 		"capi_provider?", &provider,
 	); err != nil {

--- a/starlark/kube_get.go
+++ b/starlark/kube_get.go
@@ -17,7 +17,7 @@ func KubeGetFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple
 	var kubeConfig *starlarkstruct.Struct
 
 	if err := starlark.UnpackArgs(
-		identifiers.crashdCfg, args, kwargs,
+		identifiers.kubeGet, args, kwargs,
 		"groups?", &groups,
 		"kinds?", &kinds,
 		"namespaces?", &namespaces,

--- a/starlark/kube_nodes_provider.go
+++ b/starlark/kube_nodes_provider.go
@@ -19,7 +19,7 @@ func KubeNodesProviderFn(thread *starlark.Thread, _ *starlark.Builtin, args star
 	var kubeConfig, sshConfig *starlarkstruct.Struct
 
 	if err := starlark.UnpackArgs(
-		identifiers.crashdCfg, args, kwargs,
+		identifiers.kubeNodesProvider, args, kwargs,
 		"names?", &names,
 		"labels?", &labels,
 		"kube_config?", &kubeConfig,


### PR DESCRIPTION
This patch fixes the function name input to the starlark.UnpackArgs() library function call which was set incorrectly for some of the kube functions.