### PR TITLE
Includes a new provider for CAPA managed objects

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -18,7 +18,7 @@ func newRunCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Args:  cobra.ExactArgs(1),
-		Use:   "run [flags] <file-name>",
+		Use:   "run <file-name>",
 		Short: "Executes a diagnostics script file",
 		Long:  "Executes a diagnostics script and collects its output as an archive bundle",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/examples/capa_provider.star
+++ b/examples/capa_provider.star
@@ -1,10 +1,11 @@
 conf = crashd_config(workdir=args.workdir)
-ssh_conf = ssh_config(username="capv", private_key_path=args.private_key)
+ssh_conf = ssh_config(username="ec2-user", private_key_path=args.private_key)
 kube_conf = kube_config(path=args.mc_config)
 
 #list out management and workload cluster nodes
-wc_provider=capv_provider(
+wc_provider=capa_provider(
     workload_cluster=args.cluster_name,
+    namespace=args.cluster_ns,
     ssh_config=ssh_conf,
     mgmt_kube_config=kube_conf
 )

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/pkg/errors v0.8.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
-	github.com/vladimirvivien/echo v0.0.1-alpha.4
+	github.com/vladimirvivien/echo v0.0.1-alpha.6
 	go.starlark.net v0.0.0-20200615180055-61b64bc45990
 	golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8
 	golang.org/x/sys v0.0.0-20200113162924-86b910548bc1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -159,6 +159,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/vladimirvivien/echo v0.0.1-alpha.4 h1:0E0smrv0j/7uXBXunjDeFzPHJByUojTCOlQOXswLlGs=
 github.com/vladimirvivien/echo v0.0.1-alpha.4/go.mod h1:64h/A7+5GmiBaeztyIr8BVf/07B7knV6OAP06jX+oyE=
+github.com/vladimirvivien/echo v0.0.1-alpha.6 h1:L1elSMyiiqia7+5ikH24xKIkYAlecRXP6i4YmAF1tkc=
+github.com/vladimirvivien/echo v0.0.1-alpha.6/go.mod h1:64h/A7+5GmiBaeztyIr8BVf/07B7knV6OAP06jX+oyE=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.starlark.net v0.0.0-20200615180055-61b64bc45990 h1:uDQRBsInkx8dnsM61qp8NPorEWHq2LBvVYiZK9ikCag=

--- a/k8s/bastion.go
+++ b/k8s/bastion.go
@@ -1,0 +1,27 @@
+package k8s
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/vladimirvivien/echo"
+)
+
+func FetchBastionIpAddress(clusterName, namespace, kubeConfigPath string) (string, error) {
+	if namespace == "" {
+		namespace = "default"
+	}
+	p := echo.New().RunProc(fmt.Sprintf(
+		`kubectl get awscluster/%s -o jsonpath='{.status.bastion.publicIp}' --namespace %s --kubeconfig %s`,
+		clusterName,
+		namespace,
+		kubeConfigPath,
+	))
+
+	if p.Err() != nil {
+		return "", fmt.Errorf("kubectl get awscluster failed: %s: %s", p.Err(), p.Result())
+	}
+
+	result := strings.TrimSpace(p.Result())
+	return strings.ReplaceAll(result, "'", ""), nil
+}

--- a/k8s/cluster.go
+++ b/k8s/cluster.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package k8s
+
+import (
+	"errors"
+
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+type Config interface {
+	GetClusterName() (string, error)
+	GetCurrentContext() string
+}
+
+type KubeConfig struct {
+	config *clientcmdapi.Config
+}
+
+func (kcfg *KubeConfig) GetClusterName() (string, error) {
+	currCtx := kcfg.GetCurrentContext()
+	if ctx, ok := kcfg.config.Contexts[currCtx]; ok {
+		return ctx.Cluster, nil
+	} else {
+		return "", errors.New("unknown context: " + currCtx)
+	}
+}
+
+func (kcfg *KubeConfig) GetCurrentContext() string {
+	return kcfg.config.CurrentContext
+}
+
+func LoadKubeCfg(kubeConfigPath string) (Config, error) {
+	cfg, err := clientcmd.LoadFromFile(kubeConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	return &KubeConfig{config: cfg}, nil
+}

--- a/k8s/kube_config.go
+++ b/k8s/kube_config.go
@@ -15,15 +15,15 @@ import (
 )
 
 // FetchWorkloadConfig...
-func FetchWorkloadConfig(name, mgmtKubeConfigPath string) (string, error) {
+func FetchWorkloadConfig(clusterName, clusterNamespace, mgmtKubeConfigPath string) (string, error) {
 	var filePath string
-	cmdStr := fmt.Sprintf(`kubectl get secrets/%s-kubeconfig --template '{{.data.value}}' --kubeconfig %s`, name, mgmtKubeConfigPath)
+	cmdStr := fmt.Sprintf(`kubectl get secrets/%s-kubeconfig --template '{{.data.value}}' --namespace=%s --kubeconfig %s`, clusterName, clusterNamespace, mgmtKubeConfigPath)
 	p := echo.New().RunProc(cmdStr)
 	if p.Err() != nil {
 		return filePath, fmt.Errorf("kubectl get secrets failed: %s: %s", p.Err(), p.Result())
 	}
 
-	f, err := ioutil.TempFile(os.TempDir(), fmt.Sprintf("%s-workload-config", name))
+	f, err := ioutil.TempFile(os.TempDir(), fmt.Sprintf("%s-workload-config", clusterName))
 	if err != nil {
 		return filePath, errors.Wrap(err, "Cannot create temporary file")
 	}

--- a/provider/kube_config.go
+++ b/provider/kube_config.go
@@ -12,12 +12,15 @@ import (
 
 // KubeConfig returns the kubeconfig that needs to be used by the provider.
 // The path of the management kubeconfig file gets returned if the workload cluster name is empty
-func KubeConfig(mgmtKubeConfigPath, workloadClusterName string) (string, error) {
+func KubeConfig(mgmtKubeConfigPath, workloadClusterName, workloadClusterNamespace string) (string, error) {
 	var err error
 
+	if workloadClusterNamespace == "" {
+		workloadClusterNamespace = "default"
+	}
 	kubeConfigPath := mgmtKubeConfigPath
 	if len(workloadClusterName) != 0 {
-		kubeConfigPath, err = k8s.FetchWorkloadConfig(workloadClusterName, mgmtKubeConfigPath)
+		kubeConfigPath, err = k8s.FetchWorkloadConfig(workloadClusterName, workloadClusterNamespace, mgmtKubeConfigPath)
 		if err != nil {
 			err = errors.Wrap(err, fmt.Sprintf("could not fetch kubeconfig for workload cluster %s", workloadClusterName))
 		}

--- a/starlark/capa_provider.go
+++ b/starlark/capa_provider.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package starlark
+
+import (
+	"github.com/pkg/errors"
+	"github.com/vmware-tanzu/crash-diagnostics/k8s"
+	"github.com/vmware-tanzu/crash-diagnostics/provider"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+// CapaProviderFn is a built-in starlark function that collects compute resources from a k8s cluster
+// Starlark format: capa_provider(kube_config=kube_config(), ssh_config=ssh_config()[workload_cluster=<name>, namespace=<namespace>, nodes=["foo", "bar], labels=["bar", "baz"]])
+func CapaProviderFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+
+	var (
+		workloadCluster, namespace string
+		names, labels              *starlark.List
+		sshConfig, mgmtKubeConfig  *starlarkstruct.Struct
+	)
+
+	err := starlark.UnpackArgs("capa_provider", args, kwargs,
+		"ssh_config", &sshConfig,
+		"mgmt_kube_config", &mgmtKubeConfig,
+		"workload_cluster?", &workloadCluster,
+		"namespace?", &namespace,
+		"labels?", &labels,
+		"nodes?", &names)
+	if err != nil {
+		return starlark.None, errors.Wrap(err, "failed to unpack input arguments")
+	}
+
+	if sshConfig == nil || mgmtKubeConfig == nil {
+		return starlark.None, errors.New("capa_provider requires the name of the management cluster, the ssh configuration and the management cluster kubeconfig")
+	}
+
+	if mgmtKubeConfig == nil {
+		mgmtKubeConfig = thread.Local(identifiers.kubeCfg).(*starlarkstruct.Struct)
+	}
+	mgmtKubeConfigPath, err := getKubeConfigFromStruct(mgmtKubeConfig)
+	if err != nil {
+		return starlark.None, errors.Wrap(err, "failed to extract management kubeconfig")
+	}
+
+	// if workload cluster is not supplied, then the resources for the management cluster
+	// should be enumerated
+	clusterName := workloadCluster
+	if clusterName == "" {
+		config, err := k8s.LoadKubeCfg(mgmtKubeConfigPath)
+		if err != nil {
+			return starlark.None, errors.Wrap(err, "failed to load kube config")
+		}
+		clusterName, err = config.GetClusterName()
+		if err != nil {
+			return starlark.None, errors.Wrap(err, "cannot find cluster with name "+workloadCluster)
+		}
+	}
+
+	bastionIpAddr, err := k8s.FetchBastionIpAddress(clusterName, namespace, mgmtKubeConfigPath)
+	if err != nil {
+		return starlark.None, errors.Wrap(err, "could not fetch jump host addresses")
+	}
+
+	providerConfigPath, err := provider.KubeConfig(mgmtKubeConfigPath, clusterName, namespace)
+	if err != nil {
+		return starlark.None, err
+	}
+
+	nodeAddresses, err := k8s.GetNodeAddresses(providerConfigPath, toSlice(names), toSlice(labels))
+	if err != nil {
+		return starlark.None, errors.Wrap(err, "could not fetch host addresses")
+	}
+
+	// dictionary for capa provider struct
+	capaProviderDict := starlark.StringDict{
+		"kind":       starlark.String(identifiers.capvProvider),
+		"transport":  starlark.String("ssh"),
+		"kubeconfig": starlark.String(providerConfigPath),
+	}
+
+	// add node info to dictionary
+	var nodeIps []starlark.Value
+	for _, node := range nodeAddresses {
+		nodeIps = append(nodeIps, starlark.String(node))
+	}
+	capaProviderDict["hosts"] = starlark.NewList(nodeIps)
+
+	sshConfigDict := starlark.StringDict{}
+	sshConfig.ToStringDict(sshConfigDict)
+
+	// modify ssh config jump credentials, if not specified
+	if _, err := sshConfig.Attr("jump_host"); err != nil {
+		sshConfigDict["jump_host"] = starlark.String(bastionIpAddr)
+	}
+	if _, err := sshConfig.Attr("jump_user"); err != nil {
+		sshConfigDict["jump_user"] = starlark.String("ubuntu")
+	}
+	capaProviderDict[identifiers.sshCfg] = starlarkstruct.FromStringDict(starlark.String(identifiers.sshCfg), sshConfigDict)
+
+	return starlarkstruct.FromStringDict(starlark.String(identifiers.capaProvider), capaProviderDict), nil
+}

--- a/starlark/capv_provider.go
+++ b/starlark/capv_provider.go
@@ -12,35 +12,39 @@ import (
 )
 
 // CapvProviderFn is a built-in starlark function that collects compute resources from a k8s cluster
-// Starlark format: capv_provider(kube_config=kube_config(), ssh_config=ssh_config()[workload_cluster=<name>, nodes=["foo", "bar], labels=["bar", "baz"]])
-func CapvProviderFn(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+// Starlark format: capv_provider(kube_config=kube_config(), ssh_config=ssh_config()[workload_cluster=<name>, namespace=<namespace>, nodes=["foo", "bar], labels=["bar", "baz"]])
+func CapvProviderFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 
 	var (
-		workloadCluster       string
-		names, labels         *starlark.List
-		sshConfig, kubeConfig *starlarkstruct.Struct
+		workloadCluster, namespace string
+		names, labels              *starlark.List
+		sshConfig, mgmtKubeConfig  *starlarkstruct.Struct
 	)
 
 	err := starlark.UnpackArgs("capv_provider", args, kwargs,
 		"ssh_config", &sshConfig,
-		"kube_config", &kubeConfig,
+		"mgmt_kube_config", &mgmtKubeConfig,
 		"workload_cluster?", &workloadCluster,
+		"namespace?", &namespace,
 		"labels?", &labels,
 		"nodes?", &names)
 	if err != nil {
 		return starlark.None, errors.Wrap(err, "failed to unpack input arguments")
 	}
 
-	if sshConfig == nil || kubeConfig == nil {
+	if sshConfig == nil || mgmtKubeConfig == nil {
 		return starlark.None, errors.New("capv_provider requires the name of the management cluster, the ssh configuration and the management cluster kubeconfig")
 	}
 
-	mgmtKubeConfigPath, err := getKubeConfigFromStruct(kubeConfig)
+	if mgmtKubeConfig == nil {
+		mgmtKubeConfig = thread.Local(identifiers.kubeCfg).(*starlarkstruct.Struct)
+	}
+	mgmtKubeConfigPath, err := getKubeConfigFromStruct(mgmtKubeConfig)
 	if err != nil {
 		return starlark.None, errors.Wrap(err, "failed to extract management kubeconfig")
 	}
 
-	providerConfigPath, err := provider.KubeConfig(mgmtKubeConfigPath, workloadCluster)
+	providerConfigPath, err := provider.KubeConfig(mgmtKubeConfigPath, workloadCluster, namespace)
 	if err != nil {
 		return starlark.None, err
 	}

--- a/starlark/kube_config.go
+++ b/starlark/kube_config.go
@@ -34,7 +34,8 @@ func KubeConfigFn(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, 
 	if len(path) == 0 {
 		val := provider.Constructor()
 		if constructor, ok := val.(starlark.String); ok {
-			if constructor.GoString() != identifiers.capvProvider {
+			constStr := constructor.GoString()
+			if constStr != identifiers.capvProvider && constStr != identifiers.capaProvider {
 				return starlark.None, errors.New("unknown capi provider")
 			}
 		}

--- a/starlark/ssh_config.go
+++ b/starlark/ssh_config.go
@@ -57,15 +57,20 @@ func sshConfigFn(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, k
 		pkPath = defaults.pkPath
 	}
 
-	structVal := starlarkstruct.FromStringDict(starlark.String(identifiers.sshCfg), starlark.StringDict{
+	sshConfigDict := starlark.StringDict{
 		"username":         starlark.String(uname),
 		"port":             starlark.String(port),
 		"private_key_path": starlark.String(pkPath),
 		"max_retries":      starlark.MakeInt(maxRetries),
 		"conn_timeout":     starlark.MakeInt(connTimeout),
-		"jump_user":        starlark.String(jUser),
-		"jump_host":        starlark.String(jHost),
-	})
+	}
+	if len(jUser) != 0 {
+		sshConfigDict["jump_user"] = starlark.String(jUser)
+	}
+	if len(jHost) != 0 {
+		sshConfigDict["jump_host"] = starlark.String(jHost)
+	}
+	structVal := starlarkstruct.FromStringDict(starlark.String(identifiers.sshCfg), sshConfigDict)
 
 	return structVal, nil
 }

--- a/starlark/starlark_exec.go
+++ b/starlark/starlark_exec.go
@@ -90,6 +90,7 @@ func newPredeclareds() starlark.StringDict {
 		identifiers.kubeGet:           starlark.NewBuiltin(identifiers.kubeGet, KubeGetFn),
 		identifiers.kubeNodesProvider: starlark.NewBuiltin(identifiers.kubeNodesProvider, KubeNodesProviderFn),
 		identifiers.capvProvider:      starlark.NewBuiltin(identifiers.capvProvider, CapvProviderFn),
+		identifiers.capaProvider:      starlark.NewBuiltin(identifiers.capvProvider, CapaProviderFn),
 		identifiers.setDefaults:       starlark.NewBuiltin(identifiers.setDefaults, SetDefaultsFunc),
 	}
 }

--- a/starlark/support.go
+++ b/starlark/support.go
@@ -46,6 +46,7 @@ var (
 		kubeGet           string
 		kubeNodesProvider string
 		capvProvider      string
+		capaProvider      string
 	}{
 		crashdCfg: "crashd_config",
 		kubeCfg:   "kube_config",
@@ -74,6 +75,7 @@ var (
 		kubeGet:           "kube_get",
 		kubeNodesProvider: "kube_nodes_provider",
 		capvProvider:      "capv_provider",
+		capaProvider:      "capa_provider",
 	}
 
 	defaults = struct {


### PR DESCRIPTION
Adds a new resource provider which can be used to list out resources for a CAPA managed workload cluster.
This also includes updating the capv_provider to include the workspace for the queried workload cluster.

Example:
```python
# For CAPA workload cluster with name calico-aws
wc_provider=capa_provider(
    workload_cluster="calico-aws",
    namespace="abcdef",
    ssh_config=ssh_conf,
    mgmt_kube_config=kube_config(path="/kube/config")
)
nodes = resources(provider=wc_provider)
capture(cmd="sudo df -i", resources=nodes)
capture(cmd="sudo crictl info", resources=nodes)

# For CAPA management cluster
mgmt_nodes = resources(provider=capa_provider(
    namespace="blah",
    ssh_config=ssh_conf,
    mgmt_kube_config=kube_config(path="/kube/config")
))
capture(cmd="ls -alh", resources=mgmt_nodes)
```