### PR TITLE
Updates the CLI name to crashd

### DIFF
--- a/cmd/crash-dianostics.go
+++ b/cmd/crash-dianostics.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -11,7 +12,10 @@ import (
 	"github.com/vmware-tanzu/crash-diagnostics/buildinfo"
 )
 
-const defaultLogLevel = logrus.InfoLevel
+const (
+	defaultLogLevel = logrus.InfoLevel
+	CliName         = "crashd"
+)
 
 // globalFlags flags for the command
 type globalFlags struct {
@@ -23,9 +27,9 @@ func crashDiagnosticsCommand() *cobra.Command {
 	flags := &globalFlags{debug: false}
 	cmd := &cobra.Command{
 		Args:  cobra.NoArgs,
-		Use:   "crash-diagnostics",
-		Short: "crash-diagnostics helps to troubleshoot kubernetes cluster",
-		Long:  "crash-diagnostics collects diagnostics from an unresponsive Kubernetes cluster",
+		Use:   CliName,
+		Short: fmt.Sprintf("%s helps to troubleshoot kubernetes cluster", CliName),
+		Long:  fmt.Sprintf("%s collects diagnostics from an unresponsive Kubernetes cluster", CliName),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return preRun(flags)
 		},

--- a/docs/README.md
+++ b/docs/README.md
@@ -190,7 +190,44 @@ This function configures the Cluster-API provider for AWS (CAPA).  This provider
 #### Parameters
 | Param | Description | Required |
 | -------- | -------- | -------- |
-| | | |
+| `ssh_config`|SSH configuration returned by `ssh_config()`|Yes |
+| `mgmt_kube_config` |Kubernetes configuration returned by `kube_config`|Yes|
+| `workload_cluster`|The name of a workload cluster. When specified the provider will retrieve a cluster's compute nodes for the workload cluster.|No|
+| `namespace`|The namespace in which the workload cluster was created, if `workload_cluster` is specified. If no `workload_cluster` is specified, then this should be the namespace of the management cluster.|No|
+| `labels`|A list of labels used to filter cluster's compute nodes|No|
+| `nodes` |A list of node names that can filter selected cluster nodes|No|
+
+#### Output
+`capa_provider()` returns a struct with the following fields.
+
+| Field | Description |
+| --------| --------- |
+| `kind`| The name of the provider (`capv_provider`)|
+|`transport`|The name of the transport to use (i.e. `ssh, http, etc`)|
+| `ssh_config` | A struct with SSH configuration |
+| `kube_config` | A struct with Kubernetes configuration |
+| `workload_cluster` | The name of the  |
+| `hosts`|A list of host addresses generated from cluster information|
+
+#### Example
+```python
+
+ssh=ssh_config(
+    username=os.username,
+    private_key_path="{0}/.ssh/id_rsa".format(os.home),
+    port=args.ssh_port,
+    max_retries=5,
+)
+
+kube=kube_config(path=args.kube_conf)
+
+capa_provider(
+    workload_cluster="my-wc-cluster",
+    namespace="workloads"
+    ssh_config=ssh,
+    kube_config=kube
+)
+```
 
 ### `capv_provider()`
 This function configures a provider for a Cluster-API managed cluster running on vSphere (CAPV).  By default, this provider will enumerate cluster resources for the management cluster.  However, by specifying the name of a `workload_cluster`, the provider will enumarate cluster compute resources for the workload cluster. 
@@ -199,8 +236,9 @@ This function configures a provider for a Cluster-API managed cluster running on
 | Param | Description | Required |
 | -------- | -------- | -------- |
 | `ssh_config`|SSH configuration returned by `ssh_config()`|Yes |
-| `kube_config` |Kubernetes configuration returned by `kube_config`|Yes|
+| `mgmt_kube_config` |Kubernetes configuration returned by `kube_config`|Yes|
 | `workload_cluster`|The name of a workload cluster. When specified the provider will retrieve a cluster's compute nodes for the workload cluster.|No|
+| `namespace`|The namespace in which the workload cluster was created, if `workload_cluster` is specified. If no `workload_cluster` is specified, then this should be the namespace of the management cluster.|No|
 | `labels`|A list of labels used to filter cluster's compute nodes|No|
 | `nodes` |A list of node names that can filter selected cluster nodes|No|
 

--- a/starlark/capa_provider.go
+++ b/starlark/capa_provider.go
@@ -75,9 +75,9 @@ func CapaProviderFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.
 
 	// dictionary for capa provider struct
 	capaProviderDict := starlark.StringDict{
-		"kind":       starlark.String(identifiers.capvProvider),
-		"transport":  starlark.String("ssh"),
-		"kubeconfig": starlark.String(providerConfigPath),
+		"kind":        starlark.String(identifiers.capvProvider),
+		"transport":   starlark.String("ssh"),
+		"kube_config": starlark.String(providerConfigPath),
 	}
 
 	// add node info to dictionary

--- a/starlark/capv_provider.go
+++ b/starlark/capv_provider.go
@@ -56,9 +56,9 @@ func CapvProviderFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.
 
 	// dictionary for capv provider struct
 	capvProviderDict := starlark.StringDict{
-		"kind":       starlark.String(identifiers.capvProvider),
-		"transport":  starlark.String("ssh"),
-		"kubeconfig": starlark.String(providerConfigPath),
+		"kind":        starlark.String(identifiers.capvProvider),
+		"transport":   starlark.String("ssh"),
+		"kube_config": starlark.String(providerConfigPath),
 	}
 
 	// add node info to dictionary

--- a/starlark/kube_config.go
+++ b/starlark/kube_config.go
@@ -40,7 +40,7 @@ func KubeConfigFn(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, 
 			}
 		}
 
-		pathVal, err := provider.Attr("kubeconfig")
+		pathVal, err := provider.Attr("kube_config")
 		if err != nil {
 			return starlark.None, errors.Wrap(err, "could not find the kubeconfig attribute")
 		}

--- a/starlark/kube_config_test.go
+++ b/starlark/kube_config_test.go
@@ -104,7 +104,7 @@ var _ = Describe("KubeConfigFn", func() {
 					[]starlark.Value{
 						starlark.String("capi_provider"),
 						starlarkstruct.FromStringDict(starlark.String(identifiers.capvProvider), starlark.StringDict{
-							"kubeconfig": starlark.String("/foo/bar"),
+							"kube_config": starlark.String("/foo/bar"),
 						}),
 					},
 				})
@@ -124,7 +124,7 @@ var _ = Describe("KubeConfigFn", func() {
 					[]starlark.Value{
 						starlark.String("capi_provider"),
 						starlarkstruct.FromStringDict(starlark.String("meh"), starlark.StringDict{
-							"kubeconfig": starlark.String("/foo/bar"),
+							"kube_config": starlark.String("/foo/bar"),
 						}),
 					},
 				})


### PR DESCRIPTION
The new help information for the CLI now reflects the binary name as `crashd`.
```bash
$ ./crashd --help
crashd collects diagnostics from an unresponsive Kubernetes cluster

Usage:
  crashd [command]

Available Commands:
  help        Help about any command
  run         Executes a diagnostics script file
  version     prints the crash-diagnostics version

Flags:
      --debug     sets log level to debug
  -h, --help      help for crashd
      --version   version for crashd

Use "crashd [command] --help" for more information about a command.
```

This PR also updates the `capa_provider` and `capv_provider` directives to return the k8s configuration under the key name `kube_config`. It also updates the docs with new parameter names.