### PR TITLE
Reverts using custom ssh keypair for tests

### DIFF
--- a/.github/workflows/compile-test.yaml
+++ b/.github/workflows/compile-test.yaml
@@ -20,5 +20,8 @@ jobs:
         sudo ufw allow 2200:2300/tcp
         sudo ufw enable
         sudo ufw status verbose
+        mkdir -p ~/.ssh
+        chmod 765 ~/.ssh
+        cp testing/keys/* ~/.ssh/
         GO111MODULE=on go get sigs.k8s.io/kind@v0.7.0
         GO111MODULE=on go test -timeout 600s -v -p 1 ./...

--- a/examples/kube-nodes-provider.crsh
+++ b/examples/kube-nodes-provider.crsh
@@ -10,8 +10,8 @@
 
 # setup and configuration
 ssh=ssh_config(
-    username=args.username,
-    private_key_path=args.key_path,
+    username=os.username,
+    private_key_path="{0}/.ssh/id_rsa".format(os.home),
     port=args.ssh_port,
     max_retries=5,
 )

--- a/ssh/scp_test.go
+++ b/ssh/scp_test.go
@@ -6,17 +6,24 @@ package ssh
 import (
 	"io/ioutil"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 	"testing"
-
-	testcrashd "github.com/vmware-tanzu/crash-diagnostics/testing"
 )
 
 func TestCopy(t *testing.T) {
-	usr := testcrashd.GetSSHUsername()
-	pkPath := testcrashd.GetSSHPrivateKey()
-	sshArgs := SSHArgs{User: usr, PrivateKeyPath: pkPath, Host: "127.0.0.1", Port: testSSHPort, MaxRetries: testMaxRetries}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	usr, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkPath := filepath.Join(homeDir, ".ssh/id_rsa")
+	sshArgs := SSHArgs{User: usr.Username, PrivateKeyPath: pkPath, Host: "127.0.0.1", Port: testSSHPort, MaxRetries: testMaxRetries}
 	tests := []struct {
 		name        string
 		sshArgs     SSHArgs

--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -5,15 +5,24 @@ package ssh
 
 import (
 	"bytes"
+	"os"
+	"os/user"
+	"path/filepath"
 	"strings"
 	"testing"
-
-	testcrashd "github.com/vmware-tanzu/crash-diagnostics/testing"
 )
 
 func TestRun(t *testing.T) {
-	usr := testcrashd.GetSSHUsername()
-	pkPath := testcrashd.GetSSHPrivateKey()
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	usr, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkPath := filepath.Join(homeDir, ".ssh/id_rsa")
 
 	tests := []struct {
 		name   string
@@ -23,7 +32,7 @@ func TestRun(t *testing.T) {
 	}{
 		{
 			name:   "simple cmd",
-			args:   SSHArgs{User: usr, PrivateKeyPath: pkPath, Host: "127.0.0.1", Port: testSSHPort, MaxRetries: testMaxRetries},
+			args:   SSHArgs{User: usr.Username, PrivateKeyPath: pkPath, Host: "127.0.0.1", Port: testSSHPort, MaxRetries: testMaxRetries},
 			cmd:    "echo 'Hello World!'",
 			result: "Hello World!",
 		},
@@ -43,8 +52,16 @@ func TestRun(t *testing.T) {
 }
 
 func TestRunRead(t *testing.T) {
-	usr := testcrashd.GetSSHUsername()
-	pkPath := testcrashd.GetSSHPrivateKey()
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	usr, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkPath := filepath.Join(homeDir, ".ssh/id_rsa")
 
 	tests := []struct {
 		name   string
@@ -54,7 +71,7 @@ func TestRunRead(t *testing.T) {
 	}{
 		{
 			name:   "simple cmd",
-			args:   SSHArgs{User: usr, PrivateKeyPath: pkPath, Host: "127.0.0.1", Port: testSSHPort, MaxRetries: testMaxRetries},
+			args:   SSHArgs{User: usr.Username, PrivateKeyPath: pkPath, Host: "127.0.0.1", Port: testSSHPort, MaxRetries: testMaxRetries},
 			cmd:    "echo 'Hello World!'",
 			result: "Hello World!",
 		},

--- a/ssh/test_support.go
+++ b/ssh/test_support.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-func makeTestSSHDir(t *testing.T, args SSHArgs, dir string) {
+func MakeTestSSHDir(t *testing.T, args SSHArgs, dir string) {
 	t.Logf("creating test dir over SSH: %s", dir)
 	_, err := Run(args, fmt.Sprintf(`mkdir -p %s`, dir))
 	if err != nil {
@@ -26,7 +26,7 @@ func makeTestSSHDir(t *testing.T, args SSHArgs, dir string) {
 func MakeTestSSHFile(t *testing.T, args SSHArgs, fileName, content string) {
 	srcDir := filepath.Dir(fileName)
 	if len(srcDir) > 0 && srcDir != "." {
-		makeTestSSHDir(t, args, srcDir)
+		MakeTestSSHDir(t, args, srcDir)
 	}
 
 	t.Logf("creating test file over SSH: %s", fileName)

--- a/starlark/capture_test.go
+++ b/starlark/capture_test.go
@@ -30,7 +30,7 @@ func testCaptureFuncForHostResources(t *testing.T, port string) {
 			name: "default args single machine",
 			args: func(t *testing.T) starlark.Tuple { return starlark.Tuple{starlark.String("echo 'Hello World!'")} },
 			kwargs: func(t *testing.T) []starlark.Tuple {
-				sshCfg := makeTestSSHConfig(testcrashd.GetSSHPrivateKey(), port)
+				sshCfg := makeTestSSHConfig(defaults.pkPath, port)
 				resources := starlark.NewList([]starlark.Value{makeTestSSHHostResource("127.0.0.1", sshCfg)})
 				return []starlark.Tuple{[]starlark.Value{starlark.String("resources"), resources}}
 			},
@@ -76,7 +76,7 @@ func testCaptureFuncForHostResources(t *testing.T, port string) {
 			name: "kwargs single machine",
 			args: func(t *testing.T) starlark.Tuple { return nil },
 			kwargs: func(t *testing.T) []starlark.Tuple {
-				sshCfg := makeTestSSHConfig(testcrashd.GetSSHPrivateKey(), port)
+				sshCfg := makeTestSSHConfig(defaults.pkPath, port)
 				resources := starlark.NewList([]starlark.Value{makeTestSSHHostResource("127.0.0.1", sshCfg)})
 				return []starlark.Tuple{
 					[]starlark.Value{starlark.String("cmd"), starlark.String("echo 'Hello World!'")},
@@ -127,7 +127,7 @@ func testCaptureFuncForHostResources(t *testing.T, port string) {
 			name: "multiple machines",
 			args: func(t *testing.T) starlark.Tuple { return nil },
 			kwargs: func(t *testing.T) []starlark.Tuple {
-				sshCfg := makeTestSSHConfig(testcrashd.GetSSHPrivateKey(), port)
+				sshCfg := makeTestSSHConfig(defaults.pkPath, port)
 				resources := starlark.NewList([]starlark.Value{
 					makeTestSSHHostResource("localhost", sshCfg),
 					makeTestSSHHostResource("127.0.0.1", sshCfg),
@@ -182,8 +182,8 @@ func testCaptureFuncScriptForHostResources(t *testing.T, port string) {
 		{
 			name: "default cmd multiple machines",
 			script: fmt.Sprintf(`
-set_defaults(resources(provider = host_list_provider(hosts=["127.0.0.1","localhost"], ssh_config = ssh_config(username="%s", port="%s", private_key_path="%s"))))
-result = capture("echo 'Hello World!'")`, testcrashd.GetSSHUsername(), port, testcrashd.GetSSHPrivateKey()),
+set_defaults(resources(provider = host_list_provider(hosts=["127.0.0.1","localhost"], ssh_config = ssh_config(username=os.username, port="%s"))))
+result = capture("echo 'Hello World!'")`, port),
 			eval: func(t *testing.T, script string) {
 				exe := New()
 				if err := exe.Exec("test.star", strings.NewReader(script)); err != nil {
@@ -228,9 +228,9 @@ def exec(hosts):
 	return result
 		
 # configuration
-set_defaults(ssh_config(username="%s", port="%s", private_key_path="%s"))
+set_defaults(ssh_config(username=os.username, port="%s"))
 hosts = resources(provider=host_list_provider(hosts=["127.0.0.1","localhost"]))
-result = exec(hosts)`, testcrashd.GetSSHUsername(), port, testcrashd.GetSSHPrivateKey()),
+result = exec(hosts)`, port),
 			eval: func(t *testing.T, script string) {
 				exe := New()
 				if err := exe.Exec("test.star", strings.NewReader(script)); err != nil {

--- a/starlark/copy_from_test.go
+++ b/starlark/copy_from_test.go
@@ -32,7 +32,7 @@ func testCopyFuncForHostResources(t *testing.T, port string) {
 			remoteFiles: map[string]string{"foo.txt": "FooBar"},
 			args:        func(t *testing.T) starlark.Tuple { return starlark.Tuple{starlark.String("foo.txt")} },
 			kwargs: func(t *testing.T) []starlark.Tuple {
-				sshCfg := makeTestSSHConfig(testcrashd.GetSSHPrivateKey(), port)
+				sshCfg := makeTestSSHConfig(defaults.pkPath, port)
 				resources := starlark.NewList([]starlark.Value{makeTestSSHHostResource("127.0.0.1", sshCfg)})
 				return []starlark.Tuple{[]starlark.Value{starlark.String("resources"), resources}}
 			},
@@ -82,7 +82,7 @@ func testCopyFuncForHostResources(t *testing.T, port string) {
 			remoteFiles: map[string]string{"bar/bar.txt": "BarBar", "bar/foo.txt": "FooBar", "baz.txt": "BazBuz"},
 			args:        func(t *testing.T) starlark.Tuple { return nil },
 			kwargs: func(t *testing.T) []starlark.Tuple {
-				sshCfg := makeTestSSHConfig(testcrashd.GetSSHPrivateKey(), port)
+				sshCfg := makeTestSSHConfig(defaults.pkPath, port)
 				resources := starlark.NewList([]starlark.Value{
 					makeTestSSHHostResource("localhost", sshCfg),
 					makeTestSSHHostResource("127.0.0.1", sshCfg),
@@ -143,7 +143,7 @@ func testCopyFuncForHostResources(t *testing.T, port string) {
 			remoteFiles: map[string]string{"bar/bar.txt": "BarBar", "bar/foo.txt": "FooBar", "bar/baz.csv": "BizzBuzz"},
 			args:        func(t *testing.T) starlark.Tuple { return nil },
 			kwargs: func(t *testing.T) []starlark.Tuple {
-				sshCfg := makeTestSSHConfig(testcrashd.GetSSHPrivateKey(), port)
+				sshCfg := makeTestSSHConfig(defaults.pkPath, port)
 				resources := starlark.NewList([]starlark.Value{
 					makeTestSSHHostResource("localhost", sshCfg),
 					makeTestSSHHostResource("127.0.0.1", sshCfg),
@@ -205,7 +205,7 @@ func testCopyFuncForHostResources(t *testing.T, port string) {
 		},
 	}
 
-	sshArgs := ssh.SSHArgs{User: testcrashd.GetSSHUsername(), Host: "127.0.0.1", Port: port, PrivateKeyPath: testcrashd.GetSSHPrivateKey()}
+	sshArgs := ssh.SSHArgs{User: getUsername(), Host: "127.0.0.1", Port: port}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			for file, content := range test.remoteFiles {
@@ -233,8 +233,8 @@ func testCopyFuncScriptForHostResources(t *testing.T, port string) {
 			name:        "multiple machines single copyFrom",
 			remoteFiles: map[string]string{"foobar.c": "footext", "bar/bar.txt": "BarBar", "bar/foo.txt": "FooBar", "bar/baz.csv": "BizzBuzz"},
 			script: fmt.Sprintf(`
-set_defaults(resources(provider = host_list_provider(hosts=["127.0.0.1","localhost"], ssh_config = ssh_config(username="%s", port="%s", private_key_path="%s"))))
-result = copy_from("bar/foo.txt")`, testcrashd.GetSSHUsername(), port, testcrashd.GetSSHPrivateKey()),
+set_defaults(resources(provider = host_list_provider(hosts=["127.0.0.1","localhost"], ssh_config = ssh_config(username=os.username, port="%s"))))
+result = copy_from("bar/foo.txt")`, port),
 			eval: func(t *testing.T, script string) {
 				exe := New()
 				if err := exe.Exec("test.star", strings.NewReader(script)); err != nil {
@@ -297,9 +297,9 @@ def cp(hosts):
 		return result
 		
 # configuration
-set_defaults(ssh_config(username="%s", port="%s", private_key_path="%s"))
+set_defaults(ssh_config(username=os.username, port="%s"))
 hosts = resources(provider=host_list_provider(hosts=["127.0.0.1","localhost"]))
-result = cp(hosts)`, testcrashd.GetSSHUsername(), port, testcrashd.GetSSHPrivateKey()),
+result = cp(hosts)`, port),
 			eval: func(t *testing.T, script string) {
 				exe := New()
 				if err := exe.Exec("test.star", strings.NewReader(script)); err != nil {
@@ -356,7 +356,7 @@ result = cp(hosts)`, testcrashd.GetSSHUsername(), port, testcrashd.GetSSHPrivate
 		},
 	}
 
-	sshArgs := ssh.SSHArgs{User: testcrashd.GetSSHUsername(), Host: "127.0.0.1", Port: port, PrivateKeyPath: testcrashd.GetSSHPrivateKey()}
+	sshArgs := ssh.SSHArgs{User: getUsername(), Host: "127.0.0.1", Port: port}
 	for _, test := range tests {
 		for file, content := range test.remoteFiles {
 			ssh.MakeTestSSHFile(t, sshArgs, file, content)

--- a/starlark/main_test.go
+++ b/starlark/main_test.go
@@ -20,7 +20,7 @@ func TestMain(m *testing.M) {
 
 func makeTestSSHConfig(pkPath, port string) *starlarkstruct.Struct {
 	return starlarkstruct.FromStringDict(starlarkstruct.Default, starlark.StringDict{
-		identifiers.username:       starlark.String(testcrashd.GetSSHUsername()),
+		identifiers.username:       starlark.String(getUsername()),
 		identifiers.port:           starlark.String(port),
 		identifiers.privateKeyPath: starlark.String(pkPath),
 		identifiers.maxRetries:     starlark.String(defaults.connRetries),

--- a/starlark/run_test.go
+++ b/starlark/run_test.go
@@ -27,7 +27,7 @@ func testRunFuncHostResources(t *testing.T, port string) {
 			name: "default arg single machine",
 			args: func(t *testing.T) starlark.Tuple { return starlark.Tuple{starlark.String("echo 'Hello World!'")} },
 			kwargs: func(t *testing.T) []starlark.Tuple {
-				sshCfg := makeTestSSHConfig(testcrashd.GetSSHPrivateKey(), port)
+				sshCfg := makeTestSSHConfig(defaults.pkPath, port)
 				resources := starlark.NewList([]starlark.Value{makeTestSSHHostResource("127.0.0.1", sshCfg)})
 				return []starlark.Tuple{[]starlark.Value{starlark.String("resources"), resources}}
 			},
@@ -55,7 +55,7 @@ func testRunFuncHostResources(t *testing.T, port string) {
 			name: "kwargs single machine",
 			args: func(t *testing.T) starlark.Tuple { return nil },
 			kwargs: func(t *testing.T) []starlark.Tuple {
-				sshCfg := makeTestSSHConfig(testcrashd.GetSSHPrivateKey(), port)
+				sshCfg := makeTestSSHConfig(defaults.pkPath, port)
 				resources := starlark.NewList([]starlark.Value{makeTestSSHHostResource("127.0.0.1", sshCfg)})
 				return []starlark.Tuple{
 					[]starlark.Value{starlark.String("cmd"), starlark.String("echo 'Hello World!'")},
@@ -86,7 +86,7 @@ func testRunFuncHostResources(t *testing.T, port string) {
 			name: "multiple machines",
 			args: func(t *testing.T) starlark.Tuple { return nil },
 			kwargs: func(t *testing.T) []starlark.Tuple {
-				sshCfg := makeTestSSHConfig(testcrashd.GetSSHPrivateKey(), port)
+				sshCfg := makeTestSSHConfig(defaults.pkPath, port)
 				resources := starlark.NewList([]starlark.Value{
 					makeTestSSHHostResource("localhost", sshCfg),
 					makeTestSSHHostResource("127.0.0.1", sshCfg),
@@ -141,9 +141,9 @@ func testRunFuncScriptHostResources(t *testing.T, port string) {
 		{
 			name: "default cmd multiple machines",
 			script: fmt.Sprintf(`
-set_defaults(ssh_config(username="%s", port="%s", private_key_path="%s"))
+set_defaults(ssh_config(username=os.username, port="%s"))
 set_defaults(resources(hosts=["127.0.0.1","localhost"]))
-result = run("echo 'Hello World!'")`, testcrashd.GetSSHUsername(), port, testcrashd.GetSSHPrivateKey()),
+result = run("echo 'Hello World!'")`, port),
 			eval: func(t *testing.T, script string) {
 				exe := New()
 				if err := exe.Exec("test.star", strings.NewReader(script)); err != nil {
@@ -187,8 +187,9 @@ def exec(hosts):
 	return result
 
 # configuration
-hosts = resources(provider=host_list_provider(hosts=["127.0.0.1","localhost"], ssh_config = ssh_config(username="%s", port="%s", private_key_path="%s")))
-result = exec(hosts)`, testcrashd.GetSSHUsername(), port, testcrashd.GetSSHPrivateKey()),
+ssh_config(username=os.username, port="%s")
+hosts = resources(provider=host_list_provider(hosts=["127.0.0.1","localhost"]))
+result = exec(hosts)`, port),
 			eval: func(t *testing.T, script string) {
 				exe := New()
 				if err := exe.Exec("test.star", strings.NewReader(script)); err != nil {
@@ -244,7 +245,7 @@ func TestRunFuncSSHAll(t *testing.T) {
 		test func(t *testing.T, port string)
 	}{
 		{name: "testRunFuncWithHostResources", test: testRunFuncHostResources},
-		{name: "testRunFuncScriptWithHostResources", test: testRunFuncScriptHostResources},
+		{name: "testRunFuncScriptWithHostResources", test: testRunFuncHostResources},
 	}
 
 	for _, test := range tests {

--- a/testing/setup.go
+++ b/testing/setup.go
@@ -7,9 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"math/rand"
-	"path"
-	"path/filepath"
-	"runtime"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -44,18 +41,4 @@ func NextPortValue() string {
 
 func NextResourceName() string {
 	return fmt.Sprintf("crashd-test-%x", rnd.Uint64())
-}
-
-func GetSSHKeyDirectory() string {
-	_, b, _, _ := runtime.Caller(0)
-	d := path.Join(path.Dir(b))
-	return path.Join(filepath.Dir(d), "testing", "keys")
-}
-
-func GetSSHPrivateKey() string {
-	return filepath.Join(GetSSHKeyDirectory(), "id_rsa")
-}
-
-func GetSSHUsername() string {
-	return "vivienv"
 }

--- a/testing/sshserver.go
+++ b/testing/sshserver.go
@@ -31,7 +31,7 @@ docker create \
   -e USER_NAME=$USER \
   -e SUDO_ACCESS=true \
   -p 2222:2222 \
-  -v ./crash-diagnostics/testing/keys:/config
+  -v $HOME/.ssh:/config
   linuxserver/openssh-server
 
 */
@@ -48,10 +48,7 @@ func (s *SSHServer) Start() error {
 	s.e.SetVar("CONTAINER_NAME", s.name)
 	s.e.SetVar("SSH_PORT", fmt.Sprintf("%s:2222", s.port))
 	s.e.SetVar("SSH_DOCKER_IMAGE", "vladimirvivien/openssh-server")
-	s.e.SetVar("USERNAME", GetSSHUsername())
-	s.e.SetVar("KEY_VOLUME_MOUNT", GetSSHKeyDirectory())
-
-	cmd := s.e.Eval("docker run --rm --detach --name=$CONTAINER_NAME -p $SSH_PORT -e PUBLIC_KEY_FILE=/config/id_rsa.pub -e USER_NAME=$USERNAME -e SUDO_ACCESS=true -v $KEY_VOLUME_MOUNT:/config $SSH_DOCKER_IMAGE")
+	cmd := s.e.Eval("docker run --rm --detach --name=$CONTAINER_NAME -p $SSH_PORT -e PUBLIC_KEY_FILE=/config/id_rsa.pub -e USER_NAME=$USER -e SUDO_ACCESS=true -v $HOME/.ssh:/config $SSH_DOCKER_IMAGE")
 	logrus.Debugf("Starting SSH server: %s", cmd)
 	proc := s.e.RunProc(cmd)
 	result := proc.Result()


### PR DESCRIPTION
This patch reverts the logic to use a custom keypair for testing purposes.