### PR TITLE
Adds support for passphrase protected ssh key

### DIFF
--- a/.github/workflows/compile-test.yaml
+++ b/.github/workflows/compile-test.yaml
@@ -6,10 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13.x
+        go-version: 1.15
       id: go
 
     - name: Check out code into the Go module directory

--- a/exec/executor.go
+++ b/exec/executor.go
@@ -4,10 +4,10 @@
 package exec
 
 import (
-	"fmt"
 	"io"
 	"os"
 
+	"github.com/pkg/errors"
 	"github.com/vmware-tanzu/crash-diagnostics/starlark"
 )
 
@@ -25,11 +25,12 @@ func Execute(name string, source io.Reader, args ArgMap) error {
 		star.AddPredeclared("args", starStruct)
 	}
 
-	if err := star.Exec(name, source); err != nil {
-		return fmt.Errorf("exec failed: %s", err)
+	err := star.Exec(name, source)
+	if err != nil {
+		err = errors.Wrap(err, "exec failed")
 	}
 
-	return nil
+	return err
 }
 
 func ExecuteFile(file *os.File, args ArgMap) error {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/crash-diagnostics
 
-go 1.12
+go 1.15
 
 require (
 	github.com/imdario/mergo v0.3.7 // indirect

--- a/ssh/agent.go
+++ b/ssh/agent.go
@@ -1,0 +1,175 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ssh
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/vladimirvivien/echo"
+)
+
+// ssh-agent constant identifiers
+const (
+	AgentPidIdentifier = "SSH_AGENT_PID"
+	AuthSockIdentifier = "SSH_AUTH_SOCK"
+)
+
+type Agent interface {
+	AddKey(keyPath string) error
+	RemoveKey(keyPath string) error
+	Stop() error
+	GetEnvVariables() string
+}
+
+// agentInfo captures the connection information of the ssh-agent
+type agentInfo map[string]string
+
+// agent represents an instance of the ssh-agent
+type agent struct {
+	// Pid of the ssh-agent
+	Pid string
+
+	// Authentication socket to communicate with the ssh-agent
+	AuthSockPath string
+
+	// File paths of the keys added to the ssh-agent
+	KeyPaths []string
+}
+
+// AddKey adds a key to the ssh-agent process
+func (agent *agent) AddKey(keyPath string) error {
+	e := echo.New()
+	sshAddCmd := e.Prog.Avail("ssh-add")
+	if len(sshAddCmd) == 0 {
+		return errors.New("ssh-add not found")
+	}
+
+	p := e.Env(agent.GetEnvVariables()).
+		RunProc(fmt.Sprintf("%s %s", sshAddCmd, keyPath))
+	if err := p.Err(); err != nil {
+		return errors.Wrapf(err, "could not add key %s to ssh-agent", keyPath)
+	}
+	agent.KeyPaths = append(agent.KeyPaths, keyPath)
+	return nil
+}
+
+// RemoveKey removes a key from the ssh-agent process
+func (agent *agent) RemoveKey(keyPath string) error {
+	e := echo.New()
+	sshAddCmd := e.Prog.Avail("ssh-add")
+	if len(sshAddCmd) == 0 {
+		return errors.New("ssh-add not found")
+	}
+
+	p := e.Env(agent.GetEnvVariables()).
+		RunProc(fmt.Sprintf("%s -d %s", sshAddCmd, keyPath))
+	if err := p.Err(); err != nil {
+		return errors.Wrapf(err, "could not add key %s to ssh-agent", keyPath)
+	}
+
+	return nil
+}
+
+// Stop kills the ssh-agent process.
+// It also tries to remove the added keys from the agent
+func (agent *agent) Stop() error {
+	for _, path := range agent.KeyPaths {
+		logrus.Debugf("removing key from ssh-agent: %s", path)
+		err := agent.RemoveKey(path)
+		if err != nil {
+			logrus.Warnf("failed to remove SSH key from agent: %s", err)
+		}
+	}
+
+	logrus.Debugf("stopping the ssh-agent with Pid: %s", agent.Pid)
+	p := echo.New().Env(agent.GetEnvVariables()).RunProc("ssh-agent -k")
+
+	return p.Err()
+}
+
+// GetEnvVariables returns the space separated key=value information used to communicate with the ssh-agent
+func (agent *agent) GetEnvVariables() string {
+	return fmt.Sprintf("%s=%s %s=%s", AgentPidIdentifier, agent.Pid, AuthSockIdentifier, agent.AuthSockPath)
+}
+
+// StartAgent starts the ssh-agent process and returns the SSH authentication parameters.
+func StartAgent() (Agent, error) {
+	e := echo.New()
+	sshAgentCmd := e.Prog.Avail("ssh-agent")
+	if len(sshAgentCmd) == 0 {
+		return nil, fmt.Errorf("ssh-agent not found")
+	}
+
+	p := e.RunProc(fmt.Sprintf("%s -s", sshAgentCmd))
+	if p.Err() != nil {
+		return nil, errors.Wrap(p.Err(), "failed to start ssh agent")
+	}
+
+	agentInfo, err := parseAgentInfo(p.Out())
+	if err != nil {
+		return nil, err
+	}
+	if err := validateAgentInfo(agentInfo); err != nil {
+		return nil, err
+	}
+
+	return agentFromInfo(agentInfo), nil
+}
+
+// parseAgentInfo parses the output of ssh-agent -s to determine the information
+// for the ssh authentication agent.
+// example output:
+//   SSH_AUTH_SOCK=/foo/bar.1234; export SSH_AUTH_SOCK;
+//   SSH_AGENT_PID=4567; export SSH_AGENT_PID;
+//   echo Agent pid 4567;
+func parseAgentInfo(info io.Reader) (agentInfo, error) {
+	agentInfo := map[string]string{}
+
+	scanner := bufio.NewScanner(info)
+	if err := scanner.Err(); err != nil {
+		return agentInfo, err
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		// separate the line using the semi-colon as a separator
+		if equal := strings.Index(line, ";"); equal >= 0 {
+			s := strings.Split(line, ";")[0]
+			// check if any key=value pair is present
+			if equal := strings.Index(s, "="); equal >= 0 {
+				kv := strings.Split(s, "=")
+				// store the key-value pair in the map
+				agentInfo[kv[0]] = kv[1]
+			}
+		}
+	}
+
+	return agentInfo, nil
+}
+
+// validateAgentInfo checks whether the ssh-agent information is valid
+func validateAgentInfo(info agentInfo) error {
+	if len(info) != 2 {
+		return errors.New("faulty ssh-agent identifier info")
+	}
+	for k, v := range info {
+		if !strings.Contains(strings.Join([]string{AgentPidIdentifier, AuthSockIdentifier}, ""), k) || len(v) == 0 {
+			return errors.New("faulty ssh-agent identifier info")
+		}
+	}
+	return nil
+}
+
+// agentFromInfo parses the information map and returns an instance of agent
+func agentFromInfo(agentInfo agentInfo) *agent {
+	return &agent{
+		Pid:          agentInfo[AgentPidIdentifier],
+		AuthSockPath: agentInfo[AuthSockIdentifier],
+	}
+}

--- a/ssh/agent_test.go
+++ b/ssh/agent_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ssh
+
+import (
+	"bufio"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/vladimirvivien/echo"
+)
+
+func TestParseAndValidateAgentInfo(t *testing.T) {
+	tests := []struct {
+		name      string
+		info      string
+		shouldErr bool
+	}{
+		{
+			name:      "valid info",
+			shouldErr: false,
+			info: `SSH_AUTH_SOCK=/foo/bar.1234; export SSH_AUTH_SOCK;
+SSH_AGENT_PID=4567; export SSH_AGENT_PID;
+echo Agent pid 4567;`,
+		},
+		{
+			name:      "invalid info",
+			shouldErr: true,
+			info: `FOO=/foo/bar.1234; export BAR;
+BLAH=4567; export BLOOP;
+echo lorem ipsum 4567;`,
+		},
+		{
+			name:      "invalid info",
+			shouldErr: true,
+			info: `SSH_AUTH_SOCK=/foo/bar.1234; export SSH_AUTH_SOCK;
+BLAH=4567; export BLOOP;
+echo lorem ipsum 4567;`,
+		},
+		{
+			name:      "invalid info",
+			shouldErr: true,
+			info: `FOO=/foo/bar.1234; export BAR;
+SSH_AGENT_PID=4567; export SSH_AGENT_PID;
+echo lorem ipsum 4567;`,
+		},
+		{
+			name:      "invalid info",
+			shouldErr: true,
+			info: `lorem ipsum 1;
+lorem ipsum 2.`,
+		},
+		{
+			name:      "invalid info",
+			shouldErr: true,
+			info:      "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			agentInfo, err := parseAgentInfo(strings.NewReader(test.info))
+			if err != nil {
+				t.Fail()
+			}
+			err = validateAgentInfo(agentInfo)
+			if err != nil && !test.shouldErr {
+				// unexpected failures
+				t.Fail()
+			} else if !test.shouldErr {
+				if _, ok := agentInfo[AgentPidIdentifier]; !ok {
+					t.Fail()
+				}
+				if _, ok := agentInfo[AuthSockIdentifier]; !ok {
+					t.Fail()
+				}
+			} else {
+				// asserting error scenarios
+				if err == nil {
+					t.Fail()
+				}
+			}
+		})
+	}
+}
+
+func TestStartAgent(t *testing.T) {
+	a, err := StartAgent()
+	if err != nil || a == nil {
+		t.Fatalf("error should be nil and agent should not be nil: %v", err)
+	}
+	out := echo.New().Run("ps -ax")
+	if !strings.Contains(out, "ssh-agent") {
+		t.Fatal("no ssh-agent process found")
+	}
+
+	failed := true
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, "ssh-agent") {
+			pid := strings.Split(strings.TrimSpace(line), " ")[0]
+			// set failed to false if correct ssh-agent process is found
+			agentStruct, _ := a.(*agent)
+			if pid == agentStruct.Pid {
+				failed = false
+			}
+		}
+	}
+	if failed {
+		t.Fatal("could not find agent with correct Pid")
+	}
+
+	t.Cleanup(func() {
+		_ = a.Stop()
+	})
+}
+
+func TestAgent(t *testing.T) {
+	a, err := StartAgent()
+	if err != nil {
+		t.Fatalf("failed to start agent: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		assert func(*testing.T, Agent)
+	}{
+		{
+			name: "GetEnvVariables",
+			assert: func(t *testing.T, agent Agent) {
+				vars := agent.GetEnvVariables()
+				if len(strings.Split(vars, " ")) != 2 {
+					t.Fatalf("not enough variables")
+				}
+
+				match, err := regexp.MatchString(`SSH_AGENT_PID=[0-9]+ SSH_AUTH_SOCK=\S*`, vars)
+				if err != nil || !match {
+					t.Fatalf("format does not match")
+				}
+			},
+		},
+		{
+			name: "Stop",
+			assert: func(t *testing.T, agent Agent) {
+				if err := agent.Stop(); err != nil {
+					t.Errorf("failed to stop agent: %s", err)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.assert(t, a)
+		})
+	}
+}

--- a/ssh/scp.go
+++ b/ssh/scp.go
@@ -17,7 +17,7 @@ import (
 
 // CopyFrom copies one or more files using SCP from remote host
 // and returns the paths of files that were successfully copied.
-func CopyFrom(args SSHArgs, rootDir string, sourcePath string) error {
+func CopyFrom(args SSHArgs, agent Agent, rootDir string, sourcePath string) error {
 	e := echo.New()
 	prog := e.Prog.Avail("scp")
 	if len(prog) == 0 {
@@ -43,6 +43,11 @@ func CopyFrom(args SSHArgs, rootDir string, sourcePath string) error {
 
 	effectiveCmd := fmt.Sprintf(`%s %s`, sshCmd, targetPath)
 	logrus.Debug("scp: ", effectiveCmd)
+
+	if agent != nil {
+		logrus.Debugf("Adding agent info: %s", agent.GetEnvVariables())
+		e = e.Env(agent.GetEnvVariables())
+	}
 
 	maxRetries := args.MaxRetries
 	if maxRetries == 0 {

--- a/ssh/scp_test.go
+++ b/ssh/scp_test.go
@@ -54,7 +54,7 @@ func TestCopy(t *testing.T) {
 				MakeTestSSHFile(t, test.sshArgs, file, content)
 			}
 
-			if err := CopyFrom(test.sshArgs, support.TmpDirRoot(), test.srcFile); err != nil {
+			if err := CopyFrom(test.sshArgs, nil, support.TmpDirRoot(), test.srcFile); err != nil {
 				t.Fatal(err)
 			}
 

--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -26,7 +26,7 @@ func TestRun(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			expected, err := Run(test.args, test.cmd)
+			expected, err := Run(test.args, nil, test.cmd)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -54,7 +54,7 @@ func TestRunRead(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			reader, err := RunRead(test.args, test.cmd)
+			reader, err := RunRead(test.args, nil, test.cmd)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/ssh/test_support.go
+++ b/ssh/test_support.go
@@ -43,12 +43,12 @@ import (
 
 func makeTestSSHDir(t *testing.T, args SSHArgs, dir string) {
 	t.Logf("creating test dir over SSH: %s", dir)
-	_, err := Run(args, fmt.Sprintf(`mkdir -p %s`, dir))
+	_, err := Run(args, nil, fmt.Sprintf(`mkdir -p %s`, dir))
 	if err != nil {
 		t.Fatal(err)
 	}
 	// validate
-	result, _ := Run(args, fmt.Sprintf(`ls %s`, dir))
+	result, _ := Run(args, nil, fmt.Sprintf(`ls %s`, dir))
 	t.Logf("dir created: %s", result)
 }
 
@@ -59,18 +59,18 @@ func MakeTestSSHFile(t *testing.T, args SSHArgs, filePath, content string) {
 	}
 
 	t.Logf("creating test file over SSH: %s", filePath)
-	_, err := Run(args, fmt.Sprintf(`echo '%s' > %s`, content, filePath))
+	_, err := Run(args, nil, fmt.Sprintf(`echo '%s' > %s`, content, filePath))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	result, _ := Run(args, fmt.Sprintf(`ls %s`, filePath))
+	result, _ := Run(args, nil, fmt.Sprintf(`ls %s`, filePath))
 	t.Logf("file created: %s", result)
 }
 
 func RemoveTestSSHFile(t *testing.T, args SSHArgs, fileName string) {
 	t.Logf("removing test file over SSH: %s", fileName)
-	_, err := Run(args, fmt.Sprintf(`rm -rf %s`, fileName))
+	_, err := Run(args, nil, fmt.Sprintf(`rm -rf %s`, fileName))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/starlark/capa_provider.go
+++ b/starlark/capa_provider.go
@@ -75,7 +75,7 @@ func CapaProviderFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.
 
 	// dictionary for capa provider struct
 	capaProviderDict := starlark.StringDict{
-		"kind":        starlark.String(identifiers.capvProvider),
+		"kind":        starlark.String(identifiers.capaProvider),
 		"transport":   starlark.String("ssh"),
 		"kube_config": starlark.String(providerConfigPath),
 	}

--- a/starlark/resources.go
+++ b/starlark/resources.go
@@ -65,7 +65,7 @@ func enum(provider *starlarkstruct.Struct) (*starlark.List, error) {
 	kind := trimQuotes(kindVal.String())
 
 	switch kind {
-	case identifiers.hostListProvider, identifiers.kubeNodesProvider, identifiers.capvProvider:
+	case identifiers.hostListProvider, identifiers.kubeNodesProvider, identifiers.capvProvider, identifiers.capaProvider:
 		hosts, err := provider.Attr("hosts")
 		if err != nil {
 			return nil, fmt.Errorf("hosts not found in %s", identifiers.hostListProvider)

--- a/starlark/support.go
+++ b/starlark/support.go
@@ -47,6 +47,8 @@ var (
 		kubeNodesProvider string
 		capvProvider      string
 		capaProvider      string
+
+		sshAgent string
 	}{
 		crashdCfg: "crashd_config",
 		kubeCfg:   "kube_config",
@@ -76,6 +78,8 @@ var (
 		kubeNodesProvider: "kube_nodes_provider",
 		capvProvider:      "capv_provider",
 		capaProvider:      "capa_provider",
+
+		sshAgent: "crashd_ssh_agent",
 	}
 
 	defaults = struct {


### PR DESCRIPTION
Adds the ability to start/stop an instance of the `ssh-agent` and add/remove keys to/from this `ssh-agent` instance. This instance of the agent is alive only for the scope of the execution of the Starlark script. Thus, the default instance of the ssh-agent in use by the current shell remains unchanged.

This patch adds a new Boolean parameter to the `crashd_config()` directive named as `use_ssh_agent`. Whenever this is set in the script, crashd starts a new instance of the `ssh-agent` and all the following ssh keys mentioned in the script get added to this instance of the agent. All following ssh/scp operations leverage this ssh-agent for remote connections.

Example:
```python
# starts a new instance of the ssh-agent
crashd_config(use_ssh_agent=True)
...
# adds the ssh key to the agent instance started above
ssh_config(path="/foo/bar")

provider=host_list_provider(hosts=["localhost", "127.0.0.1"], ssh_config=ssh)
hosts=resources(provider=provider)

# uses the instance of the agent started above
uptimes = run(cmd="uptime", resources=hosts)
capture(cmd="sudo df -i", resources=hosts)
...
```

For a crashd operator dealing with a passphrase protected key, instead of having to add the passphrase for the key repeatedly, the operator can leverage the `use_ssh_agent` parameter in the script.

Otherwise, the script executor can add the passphrase protected keys to the default `ssh-agent` before starting the execution of the script.

Closes: #128 