### PR TITLE
Adds .crashd directory when running the program

### DIFF
--- a/cmd/crash-dianostics.go
+++ b/cmd/crash-dianostics.go
@@ -56,10 +56,10 @@ func preRun(flags *globalFlags) error {
 	}
 	logrus.SetLevel(level)
 
-	return nil
+	return CreateCrashdDir()
 }
 
-// Run satarts the command
+// Run starts the command
 func Run() error {
 	logrus.SetOutput(os.Stdout)
 	return crashDiagnosticsCommand().Execute()

--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+)
+
+var (
+	// Directory path created at crashd runtime
+	CrashdDir = filepath.Join(os.Getenv("HOME"), ".crashd")
+	// file path of the defaults args file
+	ArgsFile = filepath.Join(CrashdDir, "args")
+)
+
+// This creates a crashd directory which can be used as a default workdir
+// for script execution. It will also house the default args file.
+func CreateCrashdDir() error {
+	if _, err := os.Stat(CrashdDir); os.IsNotExist(err) {
+		return os.Mkdir(CrashdDir, 0755)
+	}
+	return nil
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -17,11 +17,16 @@ type runFlags struct {
 	argsFile string
 }
 
+func defaultRunFlags() *runFlags {
+	return &runFlags{
+		args:     make(map[string]string),
+		argsFile: ArgsFile,
+	}
+}
+
 // newRunCommand creates a command to run the Diagnostics script a file
 func newRunCommand() *cobra.Command {
-	flags := &runFlags{
-		args: make(map[string]string),
-	}
+	flags := defaultRunFlags()
 
 	cmd := &cobra.Command{
 		Args:  cobra.ExactArgs(1),
@@ -62,7 +67,7 @@ func run(flags *runFlags, path string) error {
 func processScriptArguments(flags *runFlags) (map[string]string, error) {
 	// read inputs from the scriptArgs-file
 	scriptArgs, err := util.ReadArgsFile(flags.argsFile)
-	if err != nil {
+	if err != nil && flags.argsFile != ArgsFile {
 		return nil, errors.Wrapf(err, "failed to parse scriptArgs file: %s", flags.argsFile)
 	}
 


### PR DESCRIPTION
Create a `.crashd` dir under the `$HOME` directory which houses the fallback argsfile which will be used if no `--args-file` is passed to the `run` command.

fixes: #166 