### PR TITLE
add prog_avail_local function

### DIFF
--- a/starlark/prog_avail_local.go
+++ b/starlark/prog_avail_local.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package starlark
+
+import (
+	"fmt"
+
+	"github.com/vladimirvivien/echo"
+	"go.starlark.net/starlark"
+)
+
+// progAvailLocalFunc is a built-in starlark function that checks if a program is available locally.
+// It returns the path to the command if availble or else, returns an empty string.
+// Starlark format: prog_avail_local(prog=<prog_name>)
+func progAvailLocalFunc(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var progStr string
+	if err := starlark.UnpackArgs(
+		identifiers.progAvailLocal, args, kwargs,
+		"prog", &progStr,
+	); err != nil {
+		return starlark.None, fmt.Errorf("%s: %s", identifiers.progAvailLocal, err)
+	}
+
+	p := echo.New().Prog.Avail(progStr)
+	return starlark.String(p), nil
+}

--- a/starlark/prog_avail_local_test.go
+++ b/starlark/prog_avail_local_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package starlark
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"go.starlark.net/starlark"
+)
+
+func TestProgAvailLocalScript(t *testing.T) {
+	tests := []struct {
+		name          string
+		scriptSnippet string
+		exists        bool
+	}{
+		{
+			name:          "prog_avail_local checks for 'go' using positional args",
+			scriptSnippet: "prog_avail_local(prog='go')",
+			exists:        true,
+		},
+		{
+			name:          "prog_avail_local checks for 'go' using keyword args",
+			scriptSnippet: "prog_avail_local('go')",
+			exists:        true,
+		},
+		{
+			name:          "prog_avail_local checks for 'nonexistant' using positional args",
+			scriptSnippet: "prog_avail_local(prog='nonexistant')",
+			exists:        false,
+		},
+		{
+			name:          "prog_avail_local checks for 'nonexistant' using keyword args",
+			scriptSnippet: "prog_avail_local('nonexistant')",
+			exists:        false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			script := fmt.Sprintf(`path=%v`, test.scriptSnippet)
+			exe := New()
+			if err := exe.Exec("test.star", strings.NewReader(script)); err != nil {
+				t.Fatal(err)
+			}
+
+			resultVal := exe.result["path"]
+			if resultVal == nil {
+				t.Fatal("prog_avail_local() should be assigned to a variable for test")
+			}
+
+			result, ok := resultVal.(starlark.String)
+			if !ok {
+				t.Fatal("prog_avail_local() should return a string")
+			}
+
+			if (len(string(result)) == 0) == test.exists {
+				if test.exists {
+					t.Fatalf("expecting prog to exists but 'prog_avail_local' didnt find it")
+				} else {
+					t.Fatalf("expecting prog to not exists but 'prog_avail_local' found it")
+
+				}
+			}
+		})
+	}
+}

--- a/starlark/starlark_exec.go
+++ b/starlark/starlark_exec.go
@@ -102,6 +102,7 @@ func newPredeclareds() starlark.StringDict {
 		identifiers.archive:           starlark.NewBuiltin(identifiers.archive, archiveFunc),
 		identifiers.run:               starlark.NewBuiltin(identifiers.run, runFunc),
 		identifiers.runLocal:          starlark.NewBuiltin(identifiers.runLocal, runLocalFunc),
+		identifiers.progAvailLocal:    starlark.NewBuiltin(identifiers.progAvailLocal, progAvailLocalFunc),
 		identifiers.capture:           starlark.NewBuiltin(identifiers.capture, captureFunc),
 		identifiers.captureLocal:      starlark.NewBuiltin(identifiers.capture, captureLocalFunc),
 		identifiers.copyFrom:          starlark.NewBuiltin(identifiers.copyFrom, copyFromFunc),

--- a/starlark/support.go
+++ b/starlark/support.go
@@ -37,6 +37,7 @@ var (
 		resources        string
 		run              string
 		runLocal         string
+		progAvailLocal   string
 		capture          string
 		captureLocal     string
 		copyFrom         string
@@ -70,6 +71,7 @@ var (
 		resources:        "resources",
 		run:              "run",
 		runLocal:         "run_local",
+		progAvailLocal:   "prog_avail_local",
 		capture:          "capture",
 		captureLocal:     "capture_local",
 		copyFrom:         "copy_from",


### PR DESCRIPTION
This PR adds `prog_avail_local` support for crashd scripts.
`prog_avail_local` check if a program is available on host machine.

Example script:
```
def run():
    prog="echo"
    path = prog_avail_local(prog=prog)
    if path == "":
        print("prog '{}' is not available".format(prog))
    else:
        print("prog '{}' is available at '{}'".format(prog, path))

run()
```