### PR TITLE
Use `sliceContains` to filter the resources by `kinds`

### DIFF
--- a/k8s/client.go
+++ b/k8s/client.go
@@ -146,7 +146,7 @@ func (k8sc *Client) _search(ctx context.Context, groups, categories, kinds, name
 
 			// filter by resource kind and categories
 			for _, res := range resources.APIResources {
-				if len(kinds) > 0 && !strings.Contains(kinds, strings.ToLower(res.Kind)) {
+				if len(kinds) > 0 && !sliceContains(splitParamList(kinds), strings.ToLower(res.Kind)){
 					continue
 				}
 


### PR DESCRIPTION
fixes #210

Signed-off-by: Daniel Jiang <jiangd@vmware.com>