### PR TITLE
Modify run_local to return error (#197)

### DIFF
--- a/starlark/run_local.go
+++ b/starlark/run_local.go
@@ -23,9 +23,10 @@ func runLocalFunc(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tu
 	}
 
 	p := echo.New().RunProc(cmdStr)
+	result := p.Result()
 	if p.Err() != nil {
-		return starlark.None, fmt.Errorf("%s: %s: %s", identifiers.runLocal, p.Err(), p.Result())
+		result = fmt.Sprintf("%s error: %s: %s", identifiers.runLocal, p.Err(), p.Result())
 	}
 
-	return starlark.String(p.Result()), nil
+	return starlark.String(result), nil
 }


### PR DESCRIPTION
This patch changes built-in function run_local to return an error string,
instead of error out, at runtime. Previously, the function would cause
the script to crash by erroring out completely.

Fixes #197 