### PR TITLE
Implement starlark log script function

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -523,6 +523,25 @@ hosts=resources(
 
 copy_from(path="/var/log/kube*.log", resources=hosts)
 ```
+
+### `log()`
+This function prints a log message on the terminal.
+
+#### Parameters
+| Param | Description | Required |
+| -------- | -------- | -------- |
+| `msg`|The message to print on the screen.|Yes|
+| `prefix`|An optional prefix that is printed prior to the message.|No|
+
+#### Output
+None
+
+#### Example
+```python
+log(msg="Hello World!")
+log(msg="Failed to reach server", prefix="ERROR")
+```
+
 ### `run()`
 This function executes its specified command string on all provided compute resources automatically.  It then returns a list of result objects containing information about the remote compute resource, where the command was executed, and the result of the command. 
 

--- a/starlark/log.go
+++ b/starlark/log.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package starlark
+
+import (
+	"fmt"
+	"log"
+
+	"go.starlark.net/starlark"
+)
+
+// logFunc implements a starlark built-in func for simple message logging.
+// This iteration uses Go's standard log package.
+// Example:
+//   log(msg="message", [prefix="info"])
+func logFunc(t *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var msg string
+	var prefix string
+	if err := starlark.UnpackArgs(
+		identifiers.log, args, kwargs,
+		"msg", &msg,
+		"prefix?", &prefix,
+	); err != nil {
+		return starlark.None, fmt.Errorf("%s: %s", identifiers.log, err)
+	}
+
+	// retrieve logger from thread
+	loggerLocal := t.Local(identifiers.log)
+	if loggerLocal == nil {
+		addDefaultLogger(t)
+		loggerLocal = t.Local(identifiers.log)
+	}
+	logger := loggerLocal.(*log.Logger)
+
+	if prefix != "" {
+		logger.Printf("%s: %s", prefix, msg)
+	} else {
+		logger.Print(msg)
+	}
+
+	return starlark.None, nil
+}
+
+func addDefaultLogger(t *starlark.Thread) {
+	t.SetLocal(identifiers.log, log.Default())
+}

--- a/starlark/starlark_exec.go
+++ b/starlark/starlark_exec.go
@@ -74,6 +74,9 @@ func setupLocalDefaults(thread *starlark.Thread) error {
 	ctx := context.Background()
 	thread.SetLocal(identifiers.scriptCtx, ctx)
 
+	// add default logger
+	addDefaultLogger(thread)
+
 	if err := addDefaultCrashdConf(thread); err != nil {
 		return err
 	}

--- a/starlark/support.go
+++ b/starlark/support.go
@@ -45,6 +45,7 @@ var (
 		archive          string
 		os               string
 		setDefaults      string
+		log              string
 
 		kubeCapture       string
 		kubeGet           string
@@ -80,6 +81,7 @@ var (
 		archive:          "archive",
 		os:               "os",
 		setDefaults:      "set_defaults",
+		log:              "log",
 
 		kubeCapture:       "kube_capture",
 		kubeGet:           "kube_get",


### PR DESCRIPTION
This patch implements a log function that can be used in starlark scripts.
The implementation uses the stdlib log package to print log information.

Signed-off-by: Vladimir Vivien <vivienv@vmware.com>