### PR TITLE
Script log function fix

### DIFF
--- a/starlark/log.go
+++ b/starlark/log.go
@@ -43,5 +43,8 @@ func logFunc(t *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwarg
 }
 
 func addDefaultLogger(t *starlark.Thread) {
-	t.SetLocal(identifiers.log, log.Default())
+	loggerLocal := t.Local(identifiers.log)
+	if loggerLocal == nil {
+		t.SetLocal(identifiers.log, log.Default())
+	}
 }

--- a/starlark/starlark_exec.go
+++ b/starlark/starlark_exec.go
@@ -117,5 +117,6 @@ func newPredeclareds() starlark.StringDict {
 		identifiers.capvProvider:      starlark.NewBuiltin(identifiers.capvProvider, CapvProviderFn),
 		identifiers.capaProvider:      starlark.NewBuiltin(identifiers.capaProvider, CapaProviderFn),
 		identifiers.setDefaults:       starlark.NewBuiltin(identifiers.setDefaults, SetDefaultsFunc),
+		identifiers.log:               starlark.NewBuiltin(identifiers.log, logFunc),
 	}
 }


### PR DESCRIPTION
The previous patch missed adding the log function as a predeclared
starlark function. So this caused a bug when executing scripts that
uses the log function.

Signed-off-by: Vladimir Vivien <vivienv@vmware.com>