### PR TITLE
Support for cluster context name in kube_config function (#122)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -145,6 +145,7 @@ This configuration function declares and stores configuration needed to connect 
 | Param | Description | Required |
 | -------- | -------- | ------- |
 | `path`  | Path to the local Kubernetes config file. Default: `$HOME/.kube/config`| No |
+| `cluster_context`  | The name of a context to use when accessing the cluster. Default: (empty) | No |
 | `capi_provider` | A Cluster-API provider (see providers below) to obtain Kubernetes configurations | No |
 
 #### Output
@@ -153,11 +154,12 @@ This configuration function declares and stores configuration needed to connect 
 | Field | Description |
 | --------| --------- |
 | `path` | The path to the local Kubernetes config that was set |
+| `cluster_context` | The name of a context that was set for the cluster |
 | `capi_provider`|A provider that was set for Cluster-API usage|
 
 #### Example
 ```python
-kube_config(path=args.kube_conf)
+kube_config(path=args.kube_conf, cluster_context="my-cluster")
 ```
 ### `ssh_config()`
 This function creates configuration that can be used to connect via SSH to remote machines.

--- a/k8s/client_test.go
+++ b/k8s/client_test.go
@@ -8,6 +8,56 @@ import (
 	"testing"
 )
 
+func TestClientNew(t *testing.T) {
+	tests := []struct {
+		name string
+		test func(*testing.T)
+	}{
+		{
+			name: "client with no cluster context",
+			test: func(t *testing.T) {
+				client, err := New(support.KindKubeConfigFile())
+				if err != nil {
+					t.Fatal(err)
+				}
+				results, err := client.Search(context.TODO(), SearchParams{Kinds: []string{"pods"}})
+				if err != nil {
+					t.Fatal(err)
+				}
+				count := 0
+				for _, result := range results {
+					count = len(result.List.Items) + count
+				}
+				t.Logf("found %d objects", count)
+			},
+		},
+		{
+			name: "client with cluster context",
+			test: func(t *testing.T) {
+				client, err := New(support.KindKubeConfigFile(), support.KindClusterContextName())
+				if err != nil {
+					t.Fatal(err)
+				}
+				results, err := client.Search(context.TODO(), SearchParams{Kinds: []string{"pods"}})
+				if err != nil {
+					t.Fatal(err)
+				}
+				count := 0
+				for _, result := range results {
+					count = len(result.List.Items) + count
+				}
+				t.Logf("found %d objects", count)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.test(t)
+		})
+	}
+}
+
 func TestClient_Search(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/starlark/capa_provider.go
+++ b/starlark/capa_provider.go
@@ -47,7 +47,7 @@ func CapaProviderFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.
 	if mgmtKubeConfig == nil {
 		mgmtKubeConfig = thread.Local(identifiers.kubeCfg).(*starlarkstruct.Struct)
 	}
-	mgmtKubeConfigPath, err := getKubeConfigFromStruct(mgmtKubeConfig)
+	mgmtKubeConfigPath, err := getKubeConfigPathFromStruct(mgmtKubeConfig)
 	if err != nil {
 		return starlark.None, errors.Wrap(err, "failed to extract management kubeconfig")
 	}

--- a/starlark/capv_provider.go
+++ b/starlark/capv_provider.go
@@ -47,7 +47,7 @@ func CapvProviderFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.
 	if mgmtKubeConfig == nil {
 		mgmtKubeConfig = thread.Local(identifiers.kubeCfg).(*starlarkstruct.Struct)
 	}
-	mgmtKubeConfigPath, err := getKubeConfigFromStruct(mgmtKubeConfig)
+	mgmtKubeConfigPath, err := getKubeConfigPathFromStruct(mgmtKubeConfig)
 	if err != nil {
 		return starlark.None, errors.Wrap(err, "failed to extract management kubeconfig")
 	}

--- a/starlark/kube_capture.go
+++ b/starlark/kube_capture.go
@@ -47,11 +47,13 @@ func KubeCaptureFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.T
 	if kubeConfig == nil {
 		kubeConfig = thread.Local(identifiers.kubeCfg).(*starlarkstruct.Struct)
 	}
-	path, err := getKubeConfigFromStruct(kubeConfig)
+	path, err := getKubeConfigPathFromStruct(kubeConfig)
 	if err != nil {
 		return starlark.None, errors.Wrap(err, "failed to kubeconfig")
 	}
-	client, err := k8s.New(path)
+	clusterCtxName := getKubeConfigContextNameFromStruct(kubeConfig)
+
+	client, err := k8s.New(path, clusterCtxName)
 	if err != nil {
 		return starlark.None, errors.Wrap(err, "could not initialize search client")
 	}

--- a/starlark/kube_capture_test.go
+++ b/starlark/kube_capture_test.go
@@ -346,6 +346,7 @@ func TestKubeCapture(t *testing.T) {
 func TestKubeCaptureScript(t *testing.T) {
 	workdir := testSupport.TmpDirRoot()
 	k8sconfig := testSupport.KindKubeConfigFile()
+	clusterCtxName := testSupport.KindClusterContextName()
 
 	execute := func(t *testing.T, script string) *starlarkstruct.Struct {
 		executor := New()
@@ -369,11 +370,11 @@ func TestKubeCaptureScript(t *testing.T) {
 		eval   func(t *testing.T, script string)
 	}{
 		{
-			name: "simple search with namespaced objects",
+			name: "simple search with namespaced objects with cluster context",
 			script: fmt.Sprintf(`
 crashd_config(workdir="%s")
-set_defaults(kube_config(path="%s"))
-kube_data = kube_capture(what="objects", groups=["core"], kinds=["services"], namespaces=["default", "kube-system"])`, workdir, k8sconfig),
+set_defaults(kube_config(path="%s", cluster_context="%s"))
+kube_data = kube_capture(what="objects", groups=["core"], kinds=["services"], namespaces=["default", "kube-system"])`, workdir, k8sconfig, clusterCtxName),
 			eval: func(t *testing.T, script string) {
 				data := execute(t, script)
 
@@ -511,11 +512,11 @@ kube_data = kube_capture(what="objects", groups=["core"], categories=["all"], na
 			},
 		},
 		{
-			name: "search for all logs in a namespace",
+			name: "search for all logs in a namespace with cluster context",
 			script: fmt.Sprintf(`
 crashd_config(workdir="%s")
-set_defaults(kube_config(path="%s"))
-kube_data = kube_capture(what="logs", namespaces=["kube-system"])`, workdir, k8sconfig),
+set_defaults(kube_config(path="%s", cluster_context="%s"))
+kube_data = kube_capture(what="logs", namespaces=["kube-system"])`, workdir, k8sconfig, clusterCtxName),
 			eval: func(t *testing.T, script string) {
 				data := execute(t, script)
 

--- a/starlark/kube_config_test.go
+++ b/starlark/kube_config_test.go
@@ -44,7 +44,6 @@ var _ = Describe("kube_config", func() {
 				Expect(kubeConfigData).To(BeAssignableToTypeOf(&starlarkstruct.Struct{}))
 
 				cfg, _ := kubeConfigData.(*starlarkstruct.Struct)
-				Expect(cfg.AttrNames()).To(HaveLen(1))
 
 				val, err := cfg.Attr("path")
 				Expect(err).To(BeNil())
@@ -66,7 +65,6 @@ var _ = Describe("kube_config", func() {
 				Expect(kubeConfigData).NotTo(BeNil())
 
 				cfg, _ := kubeConfigData.(*starlarkstruct.Struct)
-				Expect(cfg.AttrNames()).To(HaveLen(1))
 
 				val, err := cfg.Attr("path")
 				Expect(err).To(BeNil())
@@ -111,7 +109,6 @@ var _ = Describe("KubeConfigFn", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cfg, _ := val.(*starlarkstruct.Struct)
-			Expect(cfg.AttrNames()).To(HaveLen(1))
 
 			path, err := cfg.Attr("path")
 			Expect(err).To(BeNil())

--- a/starlark/kube_get.go
+++ b/starlark/kube_get.go
@@ -42,12 +42,13 @@ func KubeGetFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple
 	if kubeConfig == nil {
 		kubeConfig = thread.Local(identifiers.kubeCfg).(*starlarkstruct.Struct)
 	}
-	path, err := getKubeConfigFromStruct(kubeConfig)
+	path, err := getKubeConfigPathFromStruct(kubeConfig)
 	if err != nil {
-		return starlark.None, errors.Wrap(err, "failed to kubeconfig")
+		return starlark.None, errors.Wrap(err, "failed to get kubeconfig")
 	}
+	clusterCtxName := getKubeConfigContextNameFromStruct(kubeConfig)
 
-	client, err := k8s.New(path)
+	client, err := k8s.New(path, clusterCtxName)
 	if err != nil {
 		return starlark.None, errors.Wrap(err, "could not initialize search client")
 	}

--- a/starlark/kube_get_test.go
+++ b/starlark/kube_get_test.go
@@ -149,6 +149,7 @@ func TestKubeGet(t *testing.T) {
 
 func TestKubeGetScript(t *testing.T) {
 	k8sconfig := testSupport.KindKubeConfigFile()
+	clusterName := testSupport.KindClusterContextName()
 
 	execute := func(t *testing.T, script string) *starlarkstruct.Struct {
 		executor := New()
@@ -172,11 +173,11 @@ func TestKubeGetScript(t *testing.T) {
 		eval   func(t *testing.T, script string)
 	}{
 		{
-			name: "namespaced objects as starlark objects",
+			name: "namespaced objects as starlark objects with context",
 			script: fmt.Sprintf(`
-set_defaults(kube_config(path="%s"))
+set_defaults(kube_config(path="%s", cluster_context="%s"))
 kube_data = kube_get(groups=["core"], kinds=["services"], namespaces=["default", "kube-system"])
-`, k8sconfig),
+`, k8sconfig, clusterName),
 			eval: func(t *testing.T, script string) {
 				data := execute(t, script)
 
@@ -234,11 +235,11 @@ kube_data = kube_get(groups=["core"], kinds=["nodes"])
 			},
 		},
 		{
-			name: "different categories of objects as starlark objects",
+			name: "different categories of objects as starlark objects with context",
 			script: fmt.Sprintf(`
-set_defaults(kube_config(path="%s"))
+set_defaults(kube_config(path="%s", cluster_context="%s"))
 kube_data = kube_get(categories=["all"])
-`, k8sconfig),
+`, k8sconfig, clusterName),
 			eval: func(t *testing.T, script string) {
 				data := execute(t, script)
 

--- a/starlark/kube_nodes_provider.go
+++ b/starlark/kube_nodes_provider.go
@@ -39,7 +39,7 @@ func KubeNodesProviderFn(thread *starlark.Thread, _ *starlark.Builtin, args star
 	if kubeConfig == nil {
 		kubeConfig = thread.Local(identifiers.kubeCfg).(*starlarkstruct.Struct)
 	}
-	path, err := getKubeConfigFromStruct(kubeConfig)
+	path, err := getKubeConfigPathFromStruct(kubeConfig)
 	if err != nil {
 		return starlark.None, errors.Wrap(err, "failed to kubeconfig")
 	}

--- a/testing/setup.go
+++ b/testing/setup.go
@@ -200,6 +200,10 @@ func (t *TestSupport) KindKubeConfigFile() string {
 	return t.kindKubeCfg
 }
 
+func (t *TestSupport) KindClusterContextName() string {
+	return t.kindCluster.GetKubeCtlContext()
+}
+
 func (t *TestSupport) TearDown() error {
 	var errs []error
 


### PR DESCRIPTION
This patch introduces support for cluster context name when
declaring kubeernetes configuration using the kube_config starlark script
function. Now, command functions such as kube_get and kube_capture
can create connection to the API server using the local kubectl CLI
cluster context name.

Fixes #122 
