### PR TITLE
Remove unused Go crypto/ssh package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/vladimirvivien/gexe v0.1.1
 	go.starlark.net v0.0.0-20201006213952-227f4aabceb5
-	golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	k8s.io/api v0.20.9

--- a/go.sum
+++ b/go.sum
@@ -344,9 +344,8 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 h1:hb9wdF1z5waM+dSIICn1l0DkLVDT3hqhhQsDNUmHPRE=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee h1:4yd7jl+vXjalO5ztz6Vc1VADv+S/80LGJmyl1ROJ2AI=
-golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/testing/key.go
+++ b/testing/key.go
@@ -1,151 +1,17 @@
 package testing
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	"github.com/vladimirvivien/gexe"
-	"golang.org/x/crypto/ssh"
-
-	"github.com/pkg/errors"
 )
 
-// GenerateRSAKeyFiles generates a public/private key pair and stores it in the directory passed as the input.
-func GenerateRSAKeyFiles(directory, privFileName string) error {
-	priv, err := generatePrivateKey()
-	if err != nil {
-		return errors.Wrap(err, "could not generate private key")
-	}
-	rsaFile := filepath.Join(directory, privFileName)
-	err = ioutil.WriteFile(rsaFile, encodePrivateKeyToPEM(priv), 0600)
-	if err != nil {
-		return errors.Wrap(err, "could not write private key to file")
-	}
-	logrus.Info("Created private key PEM file:", rsaFile)
-
-	pub, err := generatePublicKey(&priv.PublicKey)
-	if err != nil {
-		return errors.Wrap(err, "could not generate public key")
-	}
-
-	pubFileName := fmt.Sprintf("%s.pub", privFileName)
-	rsaPubFile := filepath.Join(directory, pubFileName)
-	err = ioutil.WriteFile(rsaPubFile, pub, 0600)
-	if err != nil {
-		return errors.Wrap(err, "could not write public key to file")
-	}
-	logrus.Info("Created public key file:", rsaPubFile)
-
-	return nil
-}
-
-func generatePrivateKey() (*rsa.PrivateKey, error) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 4096)
-	if err != nil {
-		return nil, err
-	}
-
-	// Validate Private Key
-	err = privateKey.Validate()
-	if err != nil {
-		return nil, err
-	}
-
-	return privateKey, nil
-}
-
-// encodePrivateKeyToPEM encodes Private Key from RSA to PEM format
-func encodePrivateKeyToPEM(privateKey *rsa.PrivateKey) []byte {
-	// Get ASN.1 DER format
-	privDER := x509.MarshalPKCS1PrivateKey(privateKey)
-
-	// pem.Block
-	privBlock := pem.Block{
-		Type:    "RSA PRIVATE KEY",
-		Headers: nil,
-		Bytes:   privDER,
-	}
-
-	// Private key in PEM format
-	privatePEM := pem.EncodeToMemory(&privBlock)
-
-	return privatePEM
-}
-
-// generatePublicKey take a rsa.PublicKey and return bytes suitable for writing to .pub file
-// returns in the format "ssh-rsa ..."
-func generatePublicKey(privatekey *rsa.PublicKey) ([]byte, error) {
-	publicRsaKey, err := ssh.NewPublicKey(privatekey)
-	if err != nil {
-		return nil, err
-	}
-
-	pubKeyBytes := ssh.MarshalAuthorizedKey(publicRsaKey)
-	return pubKeyBytes, nil
-}
-
-func AddKeyToAgent(keyPath string) error {
-	e := gexe.New()
-
-	logrus.Info("Starting ssh-agent if needed...")
-	sshAgentCmd := e.Prog().Avail("ssh-agent")
-	if len(sshAgentCmd) == 0 {
-		return fmt.Errorf("ssh-agent not found")
-	}
-	var agentPID string
-	if aid := e.Eval("$SSH_AGENT_PID"); len(agentPID) == 0 {
-		proc := e.RunProc(fmt.Sprintf(`/bin/sh -c 'eval "$(%s)"'`, sshAgentCmd))
-		if proc.Err() != nil {
-			return fmt.Errorf("ssh-agent failed: %s: %s", proc.Err(), proc.Result())
-		}
-		result := proc.Result()
-		logrus.Infof("ssh-agent started: %s", result)
-		agentPID = strings.Split(result, " ")[2]
-	} else {
-		agentPID = aid
-		logrus.Infof("ssh-agent pid found: %s", aid)
-	}
-
-	sshAddCmd := e.Prog().Avail("ssh-add")
-	if len(sshAddCmd) == 0 {
-		return fmt.Errorf("ssh-add not found")
-	}
-
-	logrus.Debugf("adding key to ssh-agent (pid %s): %s", agentPID, keyPath)
-
-	e.SetVar("ssh_agent_pid", agentPID)
-	p := e.RunProc(fmt.Sprintf(`/bin/sh -c 'SSH_AGENT_PID=%s %s %s'`, agentPID, sshAddCmd, keyPath))
-	if p.Err() != nil {
-		return fmt.Errorf("failed to add SSH key to agent: %s: %s", p.Err(), p.Result())
-	}
-	logrus.Infof("ssh-add result: %s", p.Result())
-	return nil
-}
-
-func RemoveKeyFromAgent(keyPath string) error {
-	e := gexe.New()
-	sshAddCmd := e.Prog().Avail("ssh-add")
-	if len(sshAddCmd) == 0 {
-		return fmt.Errorf("ssh-add not found")
-	}
-	logrus.Debugf("removing key from ssh-agent: %s", keyPath)
-	p := e.RunProc(fmt.Sprintf("%s -d %s", sshAddCmd, keyPath))
-	if p.Err() != nil {
-		return fmt.Errorf("failed to remove SSH key from agent: %s: %s", p.Err(), p.Result())
-	}
-	logrus.Infof("removal key result: %s", p.Result())
-	return nil
-}
-
+// WriteKeys copies the static private key in variable privateKey
+// to a local file.
 func WriteKeys(rootPath string) error {
 	pkPath := filepath.Join(rootPath, "id_rsa")
 	pkFile, err := os.OpenFile(pkPath, os.O_RDWR|os.O_CREATE, 0444)


### PR DESCRIPTION
This patch removes unused code that depended on Go's crypto/ssh package.
This was done to avoid CVE-202029652 (see https://access.redhat.com/security/cve/cve-2020-29652).

Signed-off-by: Vladimir Vivien <vivienv@vmware.com>