### PR TITLE
Add script that was run and logs into archive by default

### DIFF
--- a/cmd/crashd.go
+++ b/cmd/crashd.go
@@ -4,12 +4,13 @@
 package cmd
 
 import (
+	"io"
 	"os"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-
 	"github.com/vmware-tanzu/crash-diagnostics/buildinfo"
+	"github.com/vmware-tanzu/crash-diagnostics/logging"
 )
 
 const (
@@ -19,12 +20,13 @@ const (
 
 // globalFlags flags for the command
 type globalFlags struct {
-	debug bool
+	debug   bool
+	logFile string
 }
 
 // crashDiagnosticsCommand creates a main cli command
 func crashDiagnosticsCommand() *cobra.Command {
-	flags := &globalFlags{debug: false}
+	flags := &globalFlags{debug: false, logFile: "auto"}
 	cmd := &cobra.Command{
 		Args:  cobra.NoArgs,
 		Use:   CliName,
@@ -44,23 +46,47 @@ func crashDiagnosticsCommand() *cobra.Command {
 		"sets log level to debug",
 	)
 
+	cmd.PersistentFlags().StringVar(
+		&flags.logFile,
+		"log-file",
+		flags.logFile,
+		"Filepath to log to. Defaults to 'auto' which will generate a unique log file. If empty, will disable logging to a file.",
+	)
+
 	cmd.AddCommand(newRunCommand())
 	cmd.AddCommand(newBuildinfoCommand())
 	return cmd
 }
 
 func preRun(flags *globalFlags) error {
+	if err := CreateCrashdDir(); err != nil {
+		return err
+	}
+
+	if len(flags.logFile) > 0 {
+		// Log everything to file, regardless of settings for CLI.
+		filehook, err := logging.NewFileHook(flags.logFile)
+		if err != nil {
+			logrus.Warning("Failed to log to file, logging to stdout (default)")
+		} else {
+			logrus.AddHook(filehook)
+		}
+	}
+
 	level := defaultLogLevel
 	if flags.debug {
 		level = logrus.DebugLevel
 	}
-	logrus.SetLevel(level)
+	logrus.AddHook(logging.NewCLIHook(os.Stdout, level))
 
-	return CreateCrashdDir()
+	// Set to trace so all hooks fire. We will handle levels differently for CLI/file.
+	logrus.SetOutput(io.Discard)
+	logrus.SetLevel(logrus.TraceLevel)
+
+	return nil
 }
 
 // Run starts the command
 func Run() error {
-	logrus.SetOutput(os.Stdout)
 	return crashDiagnosticsCommand().Execute()
 }

--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -6,9 +6,10 @@ import (
 )
 
 var (
-	// Directory path created at crashd runtime
+	// CrashdDir is the directory path created at crashd runtime
 	CrashdDir = filepath.Join(os.Getenv("HOME"), ".crashd")
-	// file path of the defaults args file
+
+	// ArgsFile is the path of the defaults args file.
 	ArgsFile = filepath.Join(CrashdDir, "args")
 )
 

--- a/logging/cli.go
+++ b/logging/cli.go
@@ -1,0 +1,56 @@
+package logging
+
+import (
+	"io"
+
+	"github.com/sirupsen/logrus"
+)
+
+// CLIHook creates returns a hook which will log at the specified level.
+type CLIHook struct {
+	Logger *logrus.Logger
+	level  logrus.Level
+}
+
+func NewCLIHook(w io.Writer, level logrus.Level) *CLIHook {
+	logger := logrus.New()
+	logger.SetLevel(level)
+	logger.SetOutput(w)
+
+	return &CLIHook{logger, level}
+}
+
+func (hook *CLIHook) Fire(entry *logrus.Entry) error {
+	if !hook.Logger.IsLevelEnabled(entry.Level) {
+		return nil
+	}
+	switch entry.Level {
+	case logrus.PanicLevel:
+		hook.Logger.Panic(entry.Message)
+	case logrus.FatalLevel:
+		hook.Logger.Fatal(entry.Message)
+	case logrus.ErrorLevel:
+		hook.Logger.Error(entry.Message)
+	case logrus.WarnLevel:
+		hook.Logger.Warning(entry.Message)
+	case logrus.InfoLevel:
+		hook.Logger.Info(entry.Message)
+	case logrus.DebugLevel:
+		hook.Logger.Debug(entry.Message)
+	case logrus.TraceLevel:
+		hook.Logger.Trace(entry.Message)
+	default:
+		hook.Logger.Info(entry.Message)
+	}
+	return nil
+}
+
+func (hook *CLIHook) Levels() []logrus.Level {
+	output := []logrus.Level{}
+	for _, v := range logrus.AllLevels {
+		if hook.Logger.IsLevelEnabled(v) {
+			output = append(output, v)
+		}
+	}
+	return output
+}

--- a/logging/file.go
+++ b/logging/file.go
@@ -1,0 +1,125 @@
+package logging
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	AutoLogFile   = "auto"
+	logDateFormat = "2006-01-02T15-04-05"
+)
+
+// FileHook to send logs to the trace file regardless of CLI level.
+type FileHook struct {
+	// Logger is a reference to the internal Logger that this utilizes.
+	Logger *logrus.Logger
+
+	// File is a reference to the file being written to.
+	File *os.File
+
+	// FilePath is the full path used when creating the file.
+	FilePath string
+
+	// Closed reports whether the hook has been closed. Once closed
+	// it can't be written to again.
+	Closed bool
+}
+
+func NewFileHook(path string) (*FileHook, error) {
+	if path == AutoLogFile {
+		path = filepath.Join(os.Getenv("HOME"), ".crashd", getLogNameFromTime(time.Now()))
+	}
+	file, err := os.Create(path)
+	logger := logrus.New()
+	logger.SetLevel(logrus.TraceLevel)
+	logger.SetOutput(file)
+
+	logrus.Infof("Detailed logs being written to: %v", path)
+
+	return &FileHook{Logger: logger, File: file, FilePath: path}, err
+}
+
+func (hook *FileHook) Fire(entry *logrus.Entry) error {
+	if hook.Closed {
+		return nil
+	}
+	switch entry.Level {
+	case logrus.PanicLevel:
+		hook.Logger.Panic(entry.Message)
+	case logrus.FatalLevel:
+		hook.Logger.Fatal(entry.Message)
+	case logrus.ErrorLevel:
+		hook.Logger.Error(entry.Message)
+	case logrus.WarnLevel:
+		hook.Logger.Warning(entry.Message)
+	case logrus.InfoLevel:
+		hook.Logger.Info(entry.Message)
+	case logrus.DebugLevel:
+		hook.Logger.Debug(entry.Message)
+	case logrus.TraceLevel:
+		hook.Logger.Trace(entry.Message)
+	default:
+		hook.Logger.Info(entry.Message)
+	}
+	return nil
+}
+
+func (hook *FileHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+// CloseFileHooks will close each file being used for each FileHook attached to the logger.
+// If the logger passed is nil, will reference the logrus.StandardLogger().
+func CloseFileHooks(l *logrus.Logger) error {
+	// All the hooks we utilize are just tied to the standard logger.
+	logrus.Debugln("Closing log file; future log calls will not be persisted.")
+	if l == nil {
+		l = logrus.StandardLogger()
+	}
+
+	for _, fh := range GetFileHooks(l) {
+		fh.File.Close()
+		fh.Closed = true
+	}
+	return nil
+}
+
+// GetFirstFileHook is a convenience method to take an object and returns the first
+// FileHook attached to it. Accepts an interface{} since the logger objects may be put
+// into context or thread objects. The obj should be a *logrus.Logger object.
+func GetFirstFileHook(obj interface{}) *FileHook {
+	fhs := GetFileHooks(obj)
+	if len(fhs) > 0 {
+		return fhs[0]
+	}
+	return nil
+}
+
+// GetFileHooks is a convenience method to take an object and returns the
+// FileHooks attached to it. Accepts an interface{} since the logger objects may be put
+// into context or thread objects. The obj should be a *logrus.Logger object.
+func GetFileHooks(obj interface{}) []*FileHook {
+	l, ok := obj.(*logrus.Logger)
+	if !ok {
+		return nil
+	}
+	result := []*FileHook{}
+	for _, hooks := range l.Hooks {
+		for _, hook := range hooks {
+			switch fh := hook.(type) {
+			case *FileHook:
+				result = append(result, fh)
+			}
+		}
+	}
+	return result
+}
+
+func getLogNameFromTime(t time.Time) string {
+	return fmt.Sprintf("crashd_%v.log", t.Format(logDateFormat))
+}

--- a/starlark/archive.go
+++ b/starlark/archive.go
@@ -6,6 +6,8 @@ package starlark
 import (
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+	"github.com/vmware-tanzu/crash-diagnostics/logging"
 	"go.starlark.net/starlark"
 
 	"github.com/vmware-tanzu/crash-diagnostics/archiver"
@@ -13,21 +15,42 @@ import (
 
 // archiveFunc is a built-in starlark function that bundles specified directories into
 // an arhive format (i.e. tar.gz)
-// Starlark format: archive(output_file=<file name> ,source_paths=list)
+// Starlark format: archive(output_file=<file name> ,source_paths=list, includeLogs?=[True|False], includeScript?=[True|False])
 func archiveFunc(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var outputFile string
 	var paths *starlark.List
+
+	// Default to true so that it helps users in debugging.
+	includeLogs := true
+	includeScript := true
 
 	if err := starlark.UnpackArgs(
 		identifiers.archive, args, kwargs,
 		"output_file?", &outputFile,
 		"source_paths", &paths,
+		"includeLogs?", &includeLogs,
+		"includeScript?", &includeScript,
 	); err != nil {
 		return starlark.None, fmt.Errorf("%s: %s", identifiers.archive, err)
 	}
 
 	if len(outputFile) == 0 {
 		outputFile = "archive.tar.gz"
+	}
+
+	// Always include the script executed and the logs.
+	if script := thread.Local(identifiers.scriptName); includeScript && script != nil && len(script.(string)) > 0 {
+		if err := paths.Append(starlark.String(script.(string))); err != nil {
+			logrus.Warnf("Unexpected error when adding script to archive paths: %v", err)
+		}
+	}
+	if logPath := thread.Local(identifiers.logPath); includeLogs && logPath != nil && len(logPath.(string)) > 0 {
+		if err := paths.Append(starlark.String(logPath.(string))); err != nil {
+			logrus.Warnf("Unexpected error when adding log path to archive paths: %v", err)
+		}
+		if err := logging.CloseFileHooks(nil); err != nil {
+			logrus.Warnf("Unexpected error when closing file hooks: %v", err)
+		}
 	}
 
 	if paths != nil && paths.Len() == 0 {

--- a/starlark/archive_test.go
+++ b/starlark/archive_test.go
@@ -18,7 +18,7 @@ func TestArchiveFunc(t *testing.T) {
 		eval func(t *testing.T, kwargs []starlark.Tuple)
 	}{
 		{
-			name: "arhive single file",
+			name: "archive single file",
 			args: func(t *testing.T) []starlark.Tuple {
 				return []starlark.Tuple{
 					{starlark.String("output_file"), starlark.String("/tmp/out.tar.gz")},

--- a/starlark/starlark_exec.go
+++ b/starlark/starlark_exec.go
@@ -59,6 +59,7 @@ func (e *Executor) Exec(name string, source io.Reader) error {
 	if err := setupLocalDefaults(e.thread); err != nil {
 		return fmt.Errorf("failed to setup defaults: %s", err)
 	}
+	e.thread.SetLocal(identifiers.scriptName, name)
 
 	result, err := starlark.ExecFile(e.thread, name, source, e.predecs)
 	if err != nil {

--- a/starlark/support.go
+++ b/starlark/support.go
@@ -19,7 +19,8 @@ var (
 	strSanitization = regexp.MustCompile(`[^a-zA-Z0-9]`)
 
 	identifiers = struct {
-		scriptCtx string
+		scriptCtx  string
+		scriptName string
 
 		crashdCfg string
 		kubeCfg   string
@@ -46,6 +47,7 @@ var (
 		os               string
 		setDefaults      string
 		log              string
+		logPath          string
 
 		kubeCapture       string
 		kubeGet           string
@@ -82,6 +84,7 @@ var (
 		os:               "os",
 		setDefaults:      "set_defaults",
 		log:              "log",
+		logPath:          "logPath",
 
 		kubeCapture:       "kube_capture",
 		kubeGet:           "kube_get",
@@ -94,6 +97,7 @@ var (
 
 	defaults = struct {
 		crashdir    string
+		logpath     string
 		workdir     string
 		kubeconfig  string
 		sshPort     string
@@ -103,7 +107,11 @@ var (
 		connTimeout int // seconds
 	}{
 		crashdir: filepath.Join(os.Getenv("HOME"), ".crashd"),
-		workdir:  "/tmp/crashd",
+
+		// Setting a default here but the CLI should really be setting a FileHook with the value
+		// from user input.
+		logpath: filepath.Join(os.Getenv("HOME"), ".crashd", "crashd.log"),
+		workdir: "/tmp/crashd",
 		kubeconfig: func() string {
 			kubecfg := os.Getenv("KUBECONFIG")
 			if kubecfg == "" {


### PR DESCRIPTION
 - regardless of CLI verbosity, log at trace level into a file and persist into result archive
 - always include the script that was run in the result archive
 - args were not persisted since they may include auth information
 - the new features are able to be disabled; logging to file via a flag, archive options via new
keyword args.

Signed-off-by: John Schnake <jschnake@vmware.com>