### PR TITLE
cleanup the deprecated io/ioutil

### DIFF
--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -34,10 +33,10 @@ var _ = Describe("Run", func() {
 		})
 
 		DescribeTable("processScriptArguments", func(argsFileContent string, args map[string]string, size int) {
-			f, err := ioutil.TempFile(os.TempDir(), "")
+			f, err := os.CreateTemp(os.TempDir(), "")
 			Expect(err).NotTo(HaveOccurred())
 
-			err = ioutil.WriteFile(f.Name(), []byte(argsFileContent), 0644)
+			err = os.WriteFile(f.Name(), []byte(argsFileContent), 0644)
 			Expect(err).NotTo(HaveOccurred())
 
 			defer f.Close()

--- a/k8s/kube_config.go
+++ b/k8s/kube_config.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/pkg/errors"
@@ -23,7 +22,7 @@ func FetchWorkloadConfig(clusterName, clusterNamespace, mgmtKubeConfigPath strin
 		return filePath, fmt.Errorf("kubectl get secrets failed: %s: %s", p.Err(), p.Result())
 	}
 
-	f, err := ioutil.TempFile(os.TempDir(), fmt.Sprintf("%s-workload-config", clusterName))
+	f, err := os.CreateTemp(os.TempDir(), fmt.Sprintf("%s-workload-config", clusterName))
 	if err != nil {
 		return filePath, errors.Wrap(err, "Cannot create temporary file")
 	}

--- a/k8s/search_result_test.go
+++ b/k8s/search_result_test.go
@@ -5,7 +5,7 @@ package k8s
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
@@ -17,7 +17,7 @@ import (
 )
 
 var populateSearchResults = func() []SearchResult {
-	content, err := ioutil.ReadFile("../testing/search_results.json")
+	content, err := os.ReadFile("../testing/search_results.json")
 	Expect(err).NotTo(HaveOccurred())
 	Expect(len(content)).NotTo(Equal(0))
 

--- a/ssh/scp_test.go
+++ b/ssh/scp_test.go
@@ -4,7 +4,6 @@
 package ssh
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -67,7 +66,7 @@ func TestCopyFrom(t *testing.T) {
 			}
 
 			if finfo.IsDir() {
-				finfos, err := ioutil.ReadDir(expectedPath)
+				finfos, err := os.ReadDir(expectedPath)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/starlark/copy_from_test.go
+++ b/starlark/copy_from_test.go
@@ -5,7 +5,6 @@ package starlark
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -189,7 +188,7 @@ func testCopyFromFuncForHostResources(t *testing.T, port, privateKey, username s
 					}
 
 					path := filepath.Join(defaults.workdir, sanitizeStr(resource), "bar")
-					finfos, err := ioutil.ReadDir(path)
+					finfos, err := os.ReadDir(path)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -340,7 +339,7 @@ result = cp(hosts)`, username, port, privateKey),
 					}
 
 					path := filepath.Join(defaults.workdir, sanitizeStr(resource), "bar")
-					finfos, err := ioutil.ReadDir(path)
+					finfos, err := os.ReadDir(path)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/starlark/kube_capture_test.go
+++ b/starlark/kube_capture_test.go
@@ -5,7 +5,6 @@ package starlark
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -268,7 +267,7 @@ func TestKubeCapture(t *testing.T) {
 					t.Fatalf("expecting %s to be a directory", path)
 				}
 
-				files, err := ioutil.ReadDir(path)
+				files, err := os.ReadDir(path)
 				if err != nil {
 					t.Fatalf("ReadeDir(%s) failed: %s", path, err)
 				}
@@ -325,7 +324,7 @@ func TestKubeCapture(t *testing.T) {
 					t.Fatalf("expecting %s to be a directory", path)
 				}
 
-				files, err := ioutil.ReadDir(path)
+				files, err := os.ReadDir(path)
 				if err != nil {
 					t.Fatalf("ReadeDir(%s) failed: %s", path, err)
 				}
@@ -540,7 +539,7 @@ kube_data = kube_capture(what="logs", namespaces=["kube-system"])`, workdir, k8s
 					t.Fatalf("expecting %s to be a directory", path)
 				}
 
-				files, err := ioutil.ReadDir(path)
+				files, err := os.ReadDir(path)
 				if err != nil {
 					t.Fatalf("ReadeDir(%s) failed: %s", path, err)
 				}
@@ -578,7 +577,7 @@ kube_data = kube_capture(what="logs", namespaces=["kube-system"], containers=["e
 					t.Fatalf("expecting %s to be a directory", path)
 				}
 
-				files, err := ioutil.ReadDir(path)
+				files, err := os.ReadDir(path)
 				if err != nil {
 					t.Fatalf("ReadeDir(%s) failed: %s", path, err)
 				}

--- a/util/args_test.go
+++ b/util/args_test.go
@@ -4,7 +4,6 @@
 package util
 
 import (
-	"io/ioutil"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -79,10 +78,10 @@ foo= bar`)
 })
 
 var writeContentToFile = func(content string) *os.File {
-	f, err := ioutil.TempFile(os.TempDir(), "read_file_args")
+	f, err := os.CreateTemp(os.TempDir(), "read_file_args")
 	Expect(err).NotTo(HaveOccurred())
 
-	err = ioutil.WriteFile(f.Name(), []byte(content), 0644)
+	err = os.WriteFile(f.Name(), []byte(content), 0644)
 	Expect(err).NotTo(HaveOccurred())
 
 	return f


### PR DESCRIPTION
The `io/ioutil` package has already been deprecated starting from golang 1.16, please refer to https://go.dev/doc/go1.16#ioutil

Signed-off-by: Benjamin Wang <wachao@vmware.com>