### PR TITLE
Adds new parameter `output_mode` to kube_capture

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -620,18 +620,19 @@ These are functions used to execute API requests against a running Kubernetes cl
 The `kube_capture` function retrieves Kubernetes API objects and container logs.  The captured information is stored in local files with directory structure similar to that of `kubectl cluster-info dump`.
 
 #### Parameters
-| Param           | Description                                                                              | Required                    |
-|-----------------|------------------------------------------------------------------------------------------|-----------------------------|
-| `what`          | Specifies what to get inclusing `objects` or `logs`                                      | Yes                         |
-| `output_format` | The output format of the captured k8s objects. Supported formats are json & yaml         | No, uses json if omitted    |
-| `groups`        | A list of API groups from which to retrieve API objects.  The core group is named `core` | No                          |
-| `kinds`         | A list of object kinds to select                                                         | No                          |
-| `namespaces`    | A list of namespaces from which to select objects                                        | No                          |
-| `versions`      | A list of API versions used to select objects                                            | No                          |
-| `names`         | A list used to filter retrieved object by names                                          | No                          |
-| `labels`        | A list of label selector expressions used to filter objects                              | No                          |
-| `containers`    | A list of container names used to filter when selecting pod objects                      | No                          |
-| `kube_config`   | The Kubernetes configuration used for this call                                          | No, uses default if omitted |
+| Param           | Description                                                                                  | Required                        |
+|-----------------|----------------------------------------------------------------------------------------------|---------------------------------|
+| `what`          | Specifies what to get inclusing `objects` or `logs`                                          | Yes                             |
+| `output_format` | The output format of the captured k8s objects. Supported formats are json & yaml             | No, uses json if omitted        |
+| `output_mode`   | The output mode of the captured k8s objects. Supported modes are single_file & multiple_files| No, uses single_file if omitted |
+| `groups`        | A list of API groups from which to retrieve API objects.  The core group is named `core`     | No                              |
+| `kinds`         | A list of object kinds to select                                                             | No                              |
+| `namespaces`    | A list of namespaces from which to select objects                                            | No                              |
+| `versions`      | A list of API versions used to select objects                                                | No                              |
+| `names`         | A list used to filter retrieved object by names                                              | No                              |
+| `labels`        | A list of label selector expressions used to filter objects                                  | No                              |
+| `containers`    | A list of container names used to filter when selecting pod objects                          | No                              |
+| `kube_config`   | The Kubernetes configuration used for this call                                              | No, uses default if omitted     |
 
 #### Output
 Function `kube_capture` returns a struct with the following fields.

--- a/starlark/kube_capture.go
+++ b/starlark/kube_capture.go
@@ -23,12 +23,14 @@ func KubeCaptureFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.T
 	var kubeConfig *starlarkstruct.Struct
 	var what string
 	var outputFormat string
+	var outputMode string
 	logrus.Info(kwargs)
 
 	if err := starlark.UnpackArgs(
 		identifiers.kubeCapture, args, kwargs,
 		"what", &what,
 		"output_format?", &outputFormat,
+		"output_mode?", &outputMode,
 		"groups?", &groups,
 		"categories?", &categories,
 		"kinds?", &kinds,
@@ -64,7 +66,7 @@ func KubeCaptureFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.T
 	data := thread.Local(identifiers.crashdCfg)
 	cfg, _ := data.(*starlarkstruct.Struct)
 	workDirVal, _ := cfg.Attr("workdir")
-	resultDir, err := write(ctx, trimQuotes(workDirVal.String()), what, outputFormat, client, k8s.SearchParams{
+	resultDir, err := write(ctx, trimQuotes(workDirVal.String()), what, outputFormat, outputMode, client, k8s.SearchParams{
 		Groups:     toSlice(groups),
 		Categories: toSlice(categories),
 		Kinds:      toSlice(kinds),
@@ -88,7 +90,7 @@ func KubeCaptureFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.T
 		}), nil
 }
 
-func write(ctx context.Context, workdir, what, outputFormat string, client *k8s.Client, params k8s.SearchParams) (string, error) {
+func write(ctx context.Context, workdir, what, outputFormat, outputMode string, client *k8s.Client, params k8s.SearchParams) (string, error) {
 
 	logrus.Debugf("kube_capture(what=%s)", what)
 	switch what {
@@ -106,7 +108,7 @@ func write(ctx context.Context, workdir, what, outputFormat string, client *k8s.
 		return "", err
 	}
 
-	resultWriter, err := k8s.NewResultWriter(workdir, what, outputFormat, client.CoreRest)
+	resultWriter, err := k8s.NewResultWriter(workdir, what, outputFormat, outputMode, client.CoreRest)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to initialize writer")
 	}

--- a/starlark/kube_capture.go
+++ b/starlark/kube_capture.go
@@ -6,6 +6,7 @@ package starlark
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -66,7 +67,7 @@ func KubeCaptureFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.T
 	data := thread.Local(identifiers.crashdCfg)
 	cfg, _ := data.(*starlarkstruct.Struct)
 	workDirVal, _ := cfg.Attr("workdir")
-	resultDir, err := write(ctx, trimQuotes(workDirVal.String()), what, outputFormat, outputMode, client, k8s.SearchParams{
+	resultDir, err := write(ctx, trimQuotes(workDirVal.String()), what, strings.ToLower(outputFormat), strings.ToLower(outputMode), client, k8s.SearchParams{
 		Groups:     toSlice(groups),
 		Categories: toSlice(categories),
 		Kinds:      toSlice(kinds),


### PR DESCRIPTION
- By specifying output_mode=multiple-files one can force kube_capture to gather k8s resources in separate files as opposed to storing them in a single json/yaml file
