### PR TITLE
chores: use fmt or errors instead of github.com/pkg/errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ toolchain go1.23.4
 require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.36.2
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
 	github.com/vladimirvivien/gexe v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,6 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.36.2 h1:koNYke6TVk6ZmnyHrCXba/T/MoLBXFjeC1PtvYgw0A8=
 github.com/onsi/gomega v1.36.2/go.mod h1:DdwyADRjrc825LhMEkD76cHR5+pUnjhUN8GlHlRPHzY=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -5,13 +5,13 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/api/errors"
-
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -88,7 +88,7 @@ func New(kubeconfig string, clusterContextOptions ...string) (*Client, error) {
 // makeRESTConfig creates a new *rest.Config with a k8s context name if one is provided.
 func makeRESTConfig(fileName, contextName string) (*rest.Config, error) {
 	if fileName == "" {
-		return nil, fmt.Errorf("kubeconfig file path required")
+		return nil, errors.New("kubeconfig file path required")
 	}
 
 	if contextName != "" {
@@ -145,10 +145,10 @@ func (k8sc *Client) _search(ctx context.Context, groups, categories, kinds, name
 	switch {
 	case groups == "" && kinds == "" && versions == "" && categories == "":
 		// no groups, no kinds (resources), no versions, no categories provided
-		return nil, fmt.Errorf("search: at least one of {groups, kinds, versions, or categories} is required")
+		return nil, errors.New("search: at least one of {groups, kinds, versions, or categories} is required")
 	case groups == "" && kinds == "" && versions != "" && categories == "":
 		// only versions provided
-		return nil, fmt.Errorf("search: versions must be provided with at least one of {groups, kinds, or categories}")
+		return nil, errors.New("search: versions must be provided with at least one of {groups, kinds, or categories}")
 	default:
 		// build a group-to-resources map, based on the passed parameters.
 		// first, extract groups needed to build the map
@@ -227,7 +227,7 @@ func (k8sc *Client) _search(ctx context.Context, groups, categories, kinds, name
 	} else {
 		nsNames, err := getNamespaces(ctx, k8sc)
 		if err != nil {
-			if !errors.IsNotFound(err) {
+			if !apierrors.IsNotFound(err) {
 				return nil, err
 			}
 			//This is the case when namespace resource does not exist in the cluster.This is KCP case.

--- a/k8s/container_logger.go
+++ b/k8s/container_logger.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -33,7 +32,7 @@ func (c ContainerLogsImpl) Fetch(ctx context.Context, restApi rest.Interface) (i
 	req := restApi.Get().Namespace(c.namespace).Name(c.podName).Resource("pods").SubResource("log").VersionedParams(opts, scheme.ParameterCodec)
 	stream, err := req.Stream(ctx)
 	if err != nil {
-		err = errors.Wrapf(err, "failed to create container log stream for container with name %s", c.container.Name)
+		err = fmt.Errorf("failed to create container log stream for container with name %s: %w", c.container.Name, err)
 	}
 	return stream, err
 }

--- a/k8s/executor.go
+++ b/k8s/executor.go
@@ -5,14 +5,16 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/remotecommand"
-	"os"
-	"time"
 )
 
 // Executor is a struct that facilitates the execution of commands in Kubernetes pods.
@@ -64,7 +66,7 @@ func NewExecutor(kubeconfig string, clusterCtxName string, opts ExecOptions) (*E
 // makeRESTConfig creates a new *rest.Config with a k8s context name if one is provided.
 func restConfig(fileName, contextName string) (*rest.Config, error) {
 	if fileName == "" {
-		return nil, fmt.Errorf("kubeconfig file path required")
+		return nil, errors.New("kubeconfig file path required")
 	}
 
 	if contextName != "" {

--- a/k8s/kube_config.go
+++ b/k8s/kube_config.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/vladimirvivien/gexe"
 )
 
@@ -24,14 +23,14 @@ func FetchWorkloadConfig(clusterName, clusterNamespace, mgmtKubeConfigPath strin
 
 	f, err := os.CreateTemp(os.TempDir(), fmt.Sprintf("%s-workload-config", clusterName))
 	if err != nil {
-		return filePath, errors.Wrap(err, "Cannot create temporary file")
+		return filePath, fmt.Errorf("Cannot create temporary file: %w", err)
 	}
 	filePath = f.Name()
 	defer f.Close()
 
 	base64Dec := base64.NewDecoder(base64.StdEncoding, p.Out())
 	if _, err := io.Copy(f, base64Dec); err != nil {
-		return filePath, errors.Wrap(err, "error decoding workload kubeconfig")
+		return filePath, fmt.Errorf("error decoding workload kubeconfig: %w", err)
 	}
 	return filePath, nil
 }

--- a/k8s/nodes.go
+++ b/k8s/nodes.go
@@ -5,8 +5,8 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	coreV1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -14,12 +14,12 @@ import (
 func GetNodeAddresses(ctx context.Context, kubeconfigPath string, names, labels []string) ([]string, error) {
 	client, err := New(kubeconfigPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not initialize search client")
+		return nil, fmt.Errorf("could not initialize search client: %w", err)
 	}
 
 	nodes, err := getNodes(ctx, client, names, labels)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not fetch nodes")
+		return nil, fmt.Errorf("could not fetch nodes: %w", err)
 	}
 
 	var nodeIps []string

--- a/k8s/result_writer.go
+++ b/k8s/result_writer.go
@@ -2,12 +2,12 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/cli-runtime/pkg/printers"
@@ -36,11 +36,11 @@ func NewResultWriter(workdir, what, outputFormat, outputMode string, restApi res
 	} else if outputFormat == "yaml" {
 		printer = &printers.YAMLPrinter{}
 	} else {
-		return nil, errors.Errorf("unsupported output format: %s", outputFormat)
+		return nil, fmt.Errorf("unsupported output format: %s", outputFormat)
 	}
 
 	if outputMode != "" && outputMode != "single_file" && outputMode != "multiple_files" {
-		return nil, errors.Errorf("unsupported output mode: %s", outputMode)
+		return nil, fmt.Errorf("unsupported output mode: %s", outputMode)
 	}
 	singleFile := outputMode == "single_file" || outputMode == ""
 	return &ResultWriter{
@@ -58,7 +58,7 @@ func (w *ResultWriter) GetResultDir() string {
 
 func (w *ResultWriter) Write(ctx context.Context, searchResults []SearchResult) error {
 	if len(searchResults) == 0 {
-		return fmt.Errorf("cannot write empty (or nil) search result")
+		return errors.New("cannot write empty (or nil) search result")
 	}
 
 	// each result represents a list of searched item

--- a/k8s/search_params.go
+++ b/k8s/search_params.go
@@ -1,9 +1,10 @@
 package k8s
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
@@ -108,14 +109,14 @@ func parse(inputValue starlark.Value) ([]string, error) {
 	case "string":
 		val, ok := inputValue.(starlark.String)
 		if !ok {
-			err = errors.Errorf("cannot process starlark value %s", inputValue.String())
+			err = fmt.Errorf("cannot process starlark value %s", inputValue.String())
 			break
 		}
 		values = append(values, val.GoString())
 	case "list":
 		val, ok := inputValue.(*starlark.List)
 		if !ok {
-			err = errors.Errorf("cannot process starlark value %s", inputValue.String())
+			err = fmt.Errorf("cannot process starlark value %s", inputValue.String())
 			break
 		}
 		iter := val.Iterate()

--- a/provider/kube_config.go
+++ b/provider/kube_config.go
@@ -6,7 +6,6 @@ package provider
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/vmware-tanzu/crash-diagnostics/k8s"
 )
 
@@ -22,7 +21,7 @@ func KubeConfig(mgmtKubeConfigPath, workloadClusterName, workloadClusterNamespac
 	if len(workloadClusterName) != 0 {
 		kubeConfigPath, err = k8s.FetchWorkloadConfig(workloadClusterName, workloadClusterNamespace, mgmtKubeConfigPath)
 		if err != nil {
-			err = errors.Wrap(err, fmt.Sprintf("could not fetch kubeconfig for workload cluster %s", workloadClusterName))
+			err = fmt.Errorf("could not fetch kubeconfig for workload cluster %s: %w", workloadClusterName, err)
 		}
 	}
 	return kubeConfigPath, err

--- a/ssh/scp.go
+++ b/ssh/scp.go
@@ -4,6 +4,7 @@
 package ssh
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -22,7 +23,7 @@ func CopyFrom(args SSHArgs, agent Agent, rootDir string, sourcePath string) erro
 	e := gexe.New()
 	prog := e.Prog().Avail("scp")
 	if len(prog) == 0 {
-		return fmt.Errorf("scp program not found")
+		return errors.New("scp program not found")
 	}
 
 	targetPath := filepath.Join(rootDir, sourcePath)
@@ -76,15 +77,15 @@ func CopyTo(args SSHArgs, agent Agent, sourcePath, targetPath string) error {
 	e := gexe.New()
 	prog := e.Prog().Avail("scp")
 	if len(prog) == 0 {
-		return fmt.Errorf("scp program not found")
+		return errors.New("scp program not found")
 	}
 
 	if len(sourcePath) == 0 {
-		return fmt.Errorf("scp: copyTo: missing source path")
+		return errors.New("scp: copyTo: missing source path")
 	}
 
 	if len(targetPath) == 0 {
-		return fmt.Errorf("scp: copyTo: missing target path")
+		return errors.New("scp: copyTo: missing target path")
 	}
 
 	sshCmd, err := makeSCPCmdStr(prog, args)
@@ -122,15 +123,15 @@ func CopyTo(args SSHArgs, agent Agent, sourcePath, targetPath string) error {
 
 func makeSCPCmdStr(progName string, args SSHArgs) (string, error) {
 	if args.User == "" {
-		return "", fmt.Errorf("scp: user is required")
+		return "", errors.New("scp: user is required")
 	}
 	if args.Host == "" {
-		return "", fmt.Errorf("scp: host is required")
+		return "", errors.New("scp: host is required")
 	}
 
 	if args.ProxyJump != nil {
 		if args.ProxyJump.User == "" || args.ProxyJump.Host == "" {
-			return "", fmt.Errorf("scp: jump user and host are required")
+			return "", errors.New("scp: jump user and host are required")
 		}
 	}
 

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -5,6 +5,7 @@ package ssh
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -52,7 +53,7 @@ func sshRunProc(args SSHArgs, agent Agent, cmd string) (io.Reader, error) {
 	e := gexe.New()
 	prog := e.Prog().Avail("ssh")
 	if len(prog) == 0 {
-		return nil, fmt.Errorf("ssh program not found")
+		return nil, errors.New("ssh program not found")
 	}
 
 	sshCmd, err := makeSSHCmdStr(prog, args)
@@ -87,7 +88,7 @@ func sshRunProc(args SSHArgs, agent Agent, cmd string) (io.Reader, error) {
 	}
 
 	if proc == nil {
-		return nil, fmt.Errorf("ssh.run: did get process result")
+		return nil, errors.New("ssh.run: did get process result")
 	}
 
 	return proc.Out(), nil
@@ -95,15 +96,15 @@ func sshRunProc(args SSHArgs, agent Agent, cmd string) (io.Reader, error) {
 
 func makeSSHCmdStr(progName string, args SSHArgs) (string, error) {
 	if args.User == "" {
-		return "", fmt.Errorf("SSH: user is required")
+		return "", errors.New("SSH: user is required")
 	}
 	if args.Host == "" {
-		return "", fmt.Errorf("SSH: host is required")
+		return "", errors.New("SSH: host is required")
 	}
 
 	if args.ProxyJump != nil {
 		if args.ProxyJump.User == "" || args.ProxyJump.Host == "" {
-			return "", fmt.Errorf("SSH: jump user and host are required")
+			return "", errors.New("SSH: jump user and host are required")
 		}
 	}
 

--- a/starlark/capa_provider.go
+++ b/starlark/capa_provider.go
@@ -5,9 +5,9 @@ package starlark
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/vmware-tanzu/crash-diagnostics/k8s"
 	"github.com/vmware-tanzu/crash-diagnostics/provider"
 	"go.starlark.net/starlark"
@@ -32,12 +32,12 @@ func CapaProviderFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.
 		"labels?", &labels,
 		"nodes?", &names)
 	if err != nil {
-		return starlark.None, errors.Wrap(err, "failed to unpack input arguments")
+		return starlark.None, fmt.Errorf("failed to unpack input arguments: %w", err)
 	}
 
 	ctx, ok := thread.Local(identifiers.scriptCtx).(context.Context)
 	if !ok || ctx == nil {
-		return starlark.None, fmt.Errorf("script context not found")
+		return starlark.None, errors.New("script context not found")
 	}
 
 	if sshConfig == nil || mgmtKubeConfig == nil {
@@ -49,7 +49,7 @@ func CapaProviderFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.
 	}
 	mgmtKubeConfigPath, err := getKubeConfigPathFromStruct(mgmtKubeConfig)
 	if err != nil {
-		return starlark.None, errors.Wrap(err, "failed to extract management kubeconfig")
+		return starlark.None, fmt.Errorf("failed to extract management kubeconfig: %w", err)
 	}
 
 	// if workload cluster is not supplied, then the resources for the management cluster
@@ -58,17 +58,17 @@ func CapaProviderFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.
 	if clusterName == "" {
 		config, err := k8s.LoadKubeCfg(mgmtKubeConfigPath)
 		if err != nil {
-			return starlark.None, errors.Wrap(err, "failed to load kube config")
+			return starlark.None, fmt.Errorf("failed to load kube config: %w", err)
 		}
 		clusterName, err = config.GetClusterName()
 		if err != nil {
-			return starlark.None, errors.Wrap(err, "cannot find cluster with name "+workloadCluster)
+			return starlark.None, fmt.Errorf("cannot find cluster with name %s: %w", workloadCluster, err)
 		}
 	}
 
 	bastionIpAddr, err := k8s.FetchBastionIpAddress(clusterName, namespace, mgmtKubeConfigPath)
 	if err != nil {
-		return starlark.None, errors.Wrap(err, "could not fetch jump host addresses")
+		return starlark.None, fmt.Errorf("could not fetch jump host addresses: %w", err)
 	}
 
 	providerConfigPath, err := provider.KubeConfig(mgmtKubeConfigPath, clusterName, namespace)
@@ -78,7 +78,7 @@ func CapaProviderFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.
 
 	nodeAddresses, err := k8s.GetNodeAddresses(ctx, providerConfigPath, toSlice(names), toSlice(labels))
 	if err != nil {
-		return starlark.None, errors.Wrap(err, "could not fetch host addresses")
+		return starlark.None, fmt.Errorf("could not fetch host addresses: %w", err)
 	}
 
 	// dictionary for capa provider struct

--- a/starlark/capture.go
+++ b/starlark/capture.go
@@ -4,13 +4,13 @@
 package starlark
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/crash-diagnostics/ssh"
 	"go.starlark.net/starlark"
@@ -187,7 +187,7 @@ func execCaptureSSH(host, cmdStr, rootDir, fileName, desc string, agent ssh.Agen
 
 func captureOutput(source io.Reader, filePath, desc string, append bool) error {
 	if source == nil {
-		return fmt.Errorf("source reader is nill")
+		return errors.New("source reader is nill")
 	}
 
 	flag := os.O_CREATE | os.O_WRONLY

--- a/starlark/copy_from.go
+++ b/starlark/copy_from.go
@@ -4,11 +4,11 @@
 package starlark
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/crash-diagnostics/ssh"
 	"go.starlark.net/starlark"

--- a/starlark/crashd_config.go
+++ b/starlark/crashd_config.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/crash-diagnostics/ssh"
 	"github.com/vmware-tanzu/crash-diagnostics/util"
@@ -71,7 +70,7 @@ func crashdConfigFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.
 	if useSSHAgent {
 		agent, err := ssh.StartAgent()
 		if err != nil {
-			return starlark.None, errors.Wrap(err, "failed to start ssh agent")
+			return starlark.None, fmt.Errorf("failed to start ssh agent: %w", err)
 		}
 
 		// sets the ssh_agent variable in the current Starlark thread

--- a/starlark/govalue.go
+++ b/starlark/govalue.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/pkg/errors"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
 )
@@ -80,7 +79,7 @@ func (v *GoValue) ToDict() (*starlark.Dict, error) {
 				return nil, fmt.Errorf("ToDict failed value conversion: %s", err)
 			}
 			if err := dict.SetKey(key, val); err != nil {
-				return nil, errors.Wrapf(err, "failed to add key: %s", key)
+				return nil, fmt.Errorf("failed to add key: %s: %w", key, err)
 			}
 		}
 	default:

--- a/starlark/kube_config.go
+++ b/starlark/kube_config.go
@@ -4,9 +4,9 @@
 package starlark
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/vmware-tanzu/crash-diagnostics/util"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
@@ -44,7 +44,7 @@ func KubeConfigFn(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, 
 
 		pathVal, err := provider.Attr("kube_config")
 		if err != nil {
-			return starlark.None, errors.Wrap(err, "could not find the kubeconfig attribute")
+			return starlark.None, fmt.Errorf("could not find the kubeconfig attribute: %w", err)
 		}
 		pathStr, ok := pathVal.(starlark.String)
 		if !ok {
@@ -84,7 +84,7 @@ func addDefaultKubeConf(thread *starlark.Thread) error {
 func getKubeConfigPathFromStruct(kubeConfigStructVal *starlarkstruct.Struct) (string, error) {
 	kvPathVal, err := kubeConfigStructVal.Attr("path")
 	if err != nil {
-		return "", errors.Wrap(err, "failed to extract kubeconfig path")
+		return "", fmt.Errorf("failed to extract kubeconfig path: %w", err)
 	}
 	kvPathStrVal, ok := kvPathVal.(starlark.String)
 	if !ok {

--- a/starlark/os_builtins.go
+++ b/starlark/os_builtins.go
@@ -4,7 +4,7 @@
 package starlark
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"runtime"
 
@@ -29,7 +29,7 @@ func getEnvFunc(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tupl
 	}
 	key, ok := args.Index(0).(starlark.String)
 	if !ok {
-		return starlark.None, fmt.Errorf("os.getenv: invalid env key")
+		return starlark.None, errors.New("os.getenv: invalid env key")
 	}
 
 	return starlark.String(os.Getenv(string(key))), nil

--- a/starlark/resources.go
+++ b/starlark/resources.go
@@ -4,6 +4,7 @@
 package starlark
 
 import (
+	"errors"
 	"fmt"
 
 	"go.starlark.net/starlark"
@@ -52,14 +53,14 @@ func resourcesFunc(thread *starlark.Thread, b *starlark.Builtin, args starlark.T
 // info needed to execute commands.
 func enum(provider *starlarkstruct.Struct) (*starlark.List, error) {
 	if provider == nil {
-		return nil, fmt.Errorf("missing provider")
+		return nil, errors.New("missing provider")
 	}
 
 	var resources []starlark.Value
 
 	kindVal, err := provider.Attr("kind")
 	if err != nil {
-		return nil, fmt.Errorf("provider missing field kind")
+		return nil, errors.New("provider missing field kind")
 	}
 
 	kind := trimQuotes(kindVal.String())

--- a/starlark/run.go
+++ b/starlark/run.go
@@ -4,9 +4,9 @@
 package starlark
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"

--- a/starlark/set_defaults.go
+++ b/starlark/set_defaults.go
@@ -4,7 +4,9 @@
 package starlark
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
+
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
 )
@@ -27,7 +29,7 @@ func SetDefaultsFunc(thread *starlark.Thread, _ *starlark.Builtin, args starlark
 		case "struct":
 			constStr, err := GetConstructor(val)
 			if err != nil {
-				return starlark.None, errors.Wrap(err, UnknownDefaultErrStr)
+				return starlark.None, fmt.Errorf("%s: %w", UnknownDefaultErrStr, err)
 			}
 			if constStr == identifiers.kubeCfg {
 				thread.SetLocal(identifiers.kubeCfg, val)
@@ -42,7 +44,7 @@ func SetDefaultsFunc(thread *starlark.Thread, _ *starlark.Builtin, args starlark
 				resourceVal := list.Index(0)
 				constStr, err := GetConstructor(resourceVal)
 				if err != nil || constStr != identifiers.hostResource {
-					return starlark.None, errors.Wrap(err, UnknownDefaultErrStr)
+					return starlark.None, fmt.Errorf("%s: %w", UnknownDefaultErrStr, err)
 				}
 				thread.SetLocal(identifiers.resources, list)
 			}

--- a/starlark/ssh_config.go
+++ b/starlark/ssh_config.go
@@ -4,9 +4,9 @@
 package starlark
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/crash-diagnostics/ssh"
 	"go.starlark.net/starlark"
@@ -68,7 +68,7 @@ func SshConfigFn(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tup
 		}
 		logrus.Debugf("adding key %s to ssh-agent", pkPath)
 		if err := agent.AddKey(pkPath); err != nil {
-			return starlark.None, errors.Wrapf(err, "unable to add key %s", pkPath)
+			return starlark.None, fmt.Errorf("unable to add key %s: %w", pkPath, err)
 		}
 	}
 

--- a/testing/key.go
+++ b/testing/key.go
@@ -1,7 +1,7 @@
 package testing
 
 import (
-	"fmt"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -29,7 +29,7 @@ func WriteKeys(rootPath string) error {
 	defer pkFile.Close()
 	logrus.Infof("Writing private key file: %s", pkPath)
 	if _, err := io.Copy(pkFile, strings.NewReader(privateKey)); err != nil {
-		return fmt.Errorf("")
+		return errors.New("")
 	}
 
 	pubPath := filepath.Join(rootPath, "id_rsa.pub")
@@ -40,7 +40,7 @@ func WriteKeys(rootPath string) error {
 	defer pubFile.Close()
 	logrus.Infof("Writing private key file: %s", pubPath)
 	if _, err := io.Copy(pubFile, strings.NewReader(publicKey)); err != nil {
-		return fmt.Errorf("")
+		return errors.New("")
 	}
 	return nil
 }

--- a/testing/kindcluster.go
+++ b/testing/kindcluster.go
@@ -4,6 +4,7 @@
 package testing
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -147,7 +148,7 @@ spec:
 	for {
 		select {
 		case <-timeout:
-			return fmt.Errorf("timed out waiting for pod to be in Terminating state")
+			return errors.New("timed out waiting for pod to be in Terminating state")
 		case <-ticker.C:
 			p = k.e.RunProc(fmt.Sprintf(`kubectl --context kind-%s get pod stuck-pod -o jsonpath='{.status.phase}'`, k.name))
 			if p.Err() != nil {

--- a/testing/setup.go
+++ b/testing/setup.go
@@ -4,6 +4,7 @@
 package testing
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"math/rand"
@@ -174,7 +175,7 @@ func (t *TestSupport) SetupKindCluster() error {
 
 func (t *TestSupport) SetupKindKubeConfig() (string, error) {
 	if t.kindCluster == nil {
-		return "", fmt.Errorf("kind not set: call SetupKindCluster() first")
+		return "", errors.New("kind not set: call SetupKindCluster() first")
 	}
 
 	if len(t.kindKubeCfg) > 0 {

--- a/testing/sshserver.go
+++ b/testing/sshserver.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
+	"errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vladimirvivien/gexe"
 )
@@ -47,7 +47,7 @@ docker create \
 */
 func (s *SSHServer) Start() error {
 	if len(s.e.Prog().Avail("docker")) == 0 {
-		return fmt.Errorf("docker command not found")
+		return errors.New("docker command not found")
 	}
 
 	if strings.Contains(s.e.Run("docker ps"), s.name) {
@@ -77,7 +77,7 @@ func (s *SSHServer) Start() error {
 
 func (s *SSHServer) Stop() error {
 	if len(s.e.Prog().Avail("docker")) == 0 {
-		return fmt.Errorf("docker command not found")
+		return errors.New("docker command not found")
 	}
 
 	s.e.SetVar("CONTAINER_NAME", s.name)

--- a/util/args.go
+++ b/util/args.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -28,7 +27,7 @@ func ReadArgsFile(path string, args map[string]string) error {
 
 	file, err := os.Open(path)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("args file not found: %s", path))
+		return fmt.Errorf("args file not found: %s: %w", path, err)
 	}
 	defer file.Close()
 


### PR DESCRIPTION
#### Description

[github.com/pkg/errors](https://github.com/pkg/errors) is archived since Dec 1, 2021 and can be replaced with standard libraries like fmt or errors. This provides this migration

It also replaces fmt.Errorf("") with errors.New(""), fmt.Errorf with no variadic arguments 